### PR TITLE
🧪 Add tests for read_f64 utility

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -219,4 +219,31 @@ mod tests {
         assert_eq!(header.flags, 0xCC);
         assert_eq!(header.payload_len, 0x40302010);
     }
+
+    #[test]
+    fn test_read_f64_valid() {
+        let val: f64 = 3.14159265359;
+        let bytes = val.to_le_bytes();
+
+        let mut payload = vec![0, 0];
+        payload.extend_from_slice(&bytes);
+        payload.push(0);
+
+        let result = read_f64(&payload, 2);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), val);
+    }
+
+    #[test]
+    fn test_read_f64_out_of_bounds() {
+        let payload = vec![1, 2, 3, 4, 5, 6, 7]; // 7 bytes, 8 bytes needed
+        let result = read_f64(&payload, 0);
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), "read_f64 out of bounds");
+
+        let payload = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let result = read_f64(&payload, 1); // 1 + 8 > 8
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), "read_f64 out of bounds");
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap for `read_f64` in `src/protocol.rs` is addressed.
📊 **Coverage:** The happy path (correctly reading an f64 from an offset) and error conditions (out of bounds reads due to small payload or large offset) are now tested.
✨ **Result:** Test coverage for `src/protocol.rs` is improved, preventing regressions related to memory parsing limits.

---
*PR created automatically by Jules for task [17067369461684844151](https://jules.google.com/task/17067369461684844151) started by @Ahmadfauzi34*