### PR TITLE
🧪 Add test for WasmNorm::new_layer_norm

### DIFF
--- a/src/layers/norm.rs
+++ b/src/layers/norm.rs
@@ -128,3 +128,19 @@ impl WasmNorm {
         Ok(bytes)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_layer_norm() {
+        // Test with default epsilon
+        let norm_default = WasmNorm::new_layer_norm(128, None);
+        assert_eq!(norm_default.num_params(), 256); // gamma and beta for size 128 (128 * 2)
+
+        // Test with custom epsilon
+        let norm_custom = WasmNorm::new_layer_norm(64, Some(1e-6));
+        assert_eq!(norm_custom.num_params(), 128);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds missing test coverage for the `WasmNorm::new_layer_norm` function in `src/layers/norm.rs`.

📊 **Coverage:** What scenarios are now tested
The test ensures that `new_layer_norm` can correctly instantiate the Burn `LayerNorm` module with both default epsilon values (`None`) and custom specific epsilon values. It verifies correctness by asserting the total number of parameters configured during initialization matches the expected value (gamma and beta dimensions).

✨ **Result:** The improvement in test coverage
We now have automated validation that the WASM interface for `LayerNorm` instantiates correctly without panicking and maps sizes properly.

---
*PR created automatically by Jules for task [6245812545826476416](https://jules.google.com/task/6245812545826476416) started by @Ahmadfauzi34*