### PR TITLE
🧪 test: add test for read_u32 out of bounds

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -219,4 +219,17 @@ mod tests {
         assert_eq!(header.flags, 0xCC);
         assert_eq!(header.payload_len, 0x40302010);
     }
+
+    #[test]
+    fn test_read_u32_out_of_bounds() {
+        let payload = vec![0x01, 0x02, 0x03];
+        let result = read_u32(&payload, 0);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "read_u32 out of bounds");
+
+        let payload2 = vec![0x01, 0x02, 0x03, 0x04];
+        let result2 = read_u32(&payload2, 1);
+        assert!(result2.is_err());
+        assert_eq!(result2.unwrap_err(), "read_u32 out of bounds");
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: added test for the `read_u32` out of bounds error condition.
📊 **Coverage:** What scenarios are now tested: test checks if `offset + 4 > payload.len()` condition successfully returns a `read_u32 out of bounds` error. Covers payload of length 3 with offset 0 and payload of length 4 with offset 1.
✨ **Result:** The improvement in test coverage: better verification of input bounds errors in the protocol parsing module.

---
*PR created automatically by Jules for task [14800908510042909003](https://jules.google.com/task/14800908510042909003) started by @Ahmadfauzi34*