### PR TITLE
feat: implement sequential parsing, parameter caching, and graph exec…

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -9,6 +9,7 @@ pub const OP_GET_STATE:  u8 = 0x03;
 pub const OP_LOAD_STATE: u8 = 0x04;
 pub const OP_DESTROY:    u8 = 0x05;
 pub const OP_GET_PARAMS: u8 = 0x06;
+pub const OP_RUN_GRAPH:    u8 = 0x07;
 
 // ============================================================
 // LAYER TYPES — 1 file.rs = 1 engine = 1 byte

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -388,3 +388,137 @@ impl LayerRegistry {
         Ok(())
     }
 }
+
+// ============================================================
+// GRAPH EXECUTOR — jalankan rantai layer dalam 1 panggilan WASM.
+// Tensor intermediate TIDAK menyeberang boundary (kunci performa "Run").
+//
+// Wire format plan (little-endian):
+//   num_steps : u32
+//   num_slots : u32            // 1..=64 ; slot 0 = input eksternal
+//   steps     : ulang num_steps kali ->
+//               { layer_type: u8, layer_id: u32, in_slot: u8, out_slot: u8 }
+//   out_slot  : u8             // slot mana yang dikembalikan
+//
+// Aturan slot: slot 0 sudah terisi oleh `input`. Tiap langkah membaca
+// in_slot (harus sudah terisi) dan menulis hasil ke out_slot. Ini mendukung
+// rantai linear MAUPUN kipas-out (satu hasil dipakai banyak langkah).
+// ============================================================
+const MAX_SLOTS: u32 = 64;
+
+#[derive(Clone, Copy)]
+struct RunStep {
+    layer_type: u8,
+    layer_id: u32,
+    in_slot: u8,
+    out_slot: u8,
+}
+
+fn read_run_step(c: &mut PayloadCursor) -> Result<RunStep, String> {
+    Ok(RunStep {
+        layer_type: c.read_u8()?,
+        layer_id: c.read_u32()?,
+        in_slot: c.read_u8()?,
+        out_slot: c.read_u8()?,
+    })
+}
+
+fn contains_layer(reg: &LayerRegistry, layer_type: u8, layer_id: u32) -> bool {
+    match layer_type {
+        LAYER_LINEAR     => reg.linears.contains_key(&layer_id),
+        LAYER_NORM       => reg.norms.contains_key(&layer_id),
+        LAYER_CONV       => reg.convs.contains_key(&layer_id),
+        LAYER_ACTIVATION => reg.activations.contains_key(&layer_id),
+        LAYER_EMBEDDING  => reg.embeddings.contains_key(&layer_id),
+        LAYER_POOL       => reg.pools.contains_key(&layer_id),
+        LAYER_SHIFT      => reg.shifts.contains_key(&layer_id),
+        LAYER_GHOST      => reg.ghosts.contains_key(&layer_id),
+        LAYER_SEBLOCK    => reg.seblocks.contains_key(&layer_id),
+        _ => false,
+    }
+}
+
+// Pass 1: validasi SEMUA hal (keberadaan layer + dataflow slot) TANPA eksekusi.
+// Mengembalikan (num_steps, num_slots, out_slot) untuk dipakai pass 2.
+fn validate_plan(reg: &LayerRegistry, plan: &[u8]) -> Result<(u32, u32, u8), String> {
+    let mut c = PayloadCursor::new(plan);
+    let num_steps = c.read_u32()?;
+    let num_slots = c.read_u32()?;
+
+    if num_steps == 0 {
+        return Err("run_graph: plan has no steps".into());
+    }
+    if !(1..=MAX_SLOTS).contains(&num_slots) {
+        return Err(format!(
+            "run_graph: num_slots must be 1..={}, got {}",
+            MAX_SLOTS, num_slots
+        ));
+    }
+
+    let mut filled: u64 = 1; // bit 0 = slot 0 (input eksternal) sudah terisi
+    for _ in 0..num_steps {
+        let s = read_run_step(&mut c)?;
+        let in_slot = s.in_slot as u32;
+        let out_slot = s.out_slot as u32;
+
+        if in_slot >= num_slots || out_slot >= num_slots {
+            return Err(format!(
+                "run_graph: slot index out of range (num_slots={})",
+                num_slots
+            ));
+        }
+        if (filled >> in_slot) & 1 == 0 {
+            return Err(format!("run_graph: input slot {} is empty", in_slot));
+        }
+        if !contains_layer(reg, s.layer_type, s.layer_id) {
+            return Err(format!(
+                "run_graph: layer type 0x{:02X} id {} not found",
+                s.layer_type, s.layer_id
+            ));
+        }
+        filled |= 1u64 << out_slot; // out_slot < 64 dijamin di atas, shift aman
+    }
+
+    let out_slot = c.read_u8()? as u32;
+    if out_slot >= num_slots {
+        return Err(format!("run_graph: output slot {} out of range", out_slot));
+    }
+    if (filled >> out_slot) & 1 == 0 {
+        return Err(format!(
+            "run_graph: output slot {} is never written",
+            out_slot
+        ));
+    }
+    Ok((num_steps, num_slots, out_slot as u8))
+}
+
+#[wasm_bindgen]
+impl LayerRegistry {
+    #[wasm_bindgen(js_name = runGraph)]
+    pub fn run_graph(&self, plan: &[u8], input: &WasmTensor) -> Result<WasmTensor, String> {
+        // Pass 1: fail-fast, tidak ada eksekusi kalau plan tidak valid.
+        let (num_steps, num_slots, out_slot) = validate_plan(self, plan)?;
+
+        // Pass 2: eksekusi. Tensor intermediate hidup di Rust saja.
+        let mut c = PayloadCursor::new(plan);
+        let _ = c.read_u32()?; // num_steps (baca ulang)
+        let _ = c.read_u32()?; // num_slots (baca ulang)
+
+        let mut slots: Vec<Option<WasmTensor>> = (0..num_slots as usize).map(|_| None).collect();
+        slots[0] = Some(input.clone());
+
+        for _ in 0..num_steps {
+            let s = read_run_step(&mut c)?;
+            let inp = slots[s.in_slot as usize]
+                .as_ref()
+                .ok_or_else(|| format!("run_graph: runtime empty slot {}", s.in_slot))?;
+            // Pakai dispatch yang SUDAH ADA — tidak ada duplikasi 9 cabang.
+            let out = self.forward_layer(s.layer_id, s.layer_type, inp)?;
+            slots[s.out_slot as usize] = Some(out);
+        }
+
+        slots[out_slot as usize]
+            .take()
+            .ok_or_else(|| format!("run_graph: runtime empty output slot {}", out_slot))
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,16 +1,28 @@
 #[cfg(test)]
 mod tests {
-    use crate::protocol::{PacketHeader, PayloadCursor};
+    use crate::protocol::{
+        PacketHeader, PayloadCursor, ACT_RELU, LAYER_ACTIVATION, LAYER_LINEAR, OP_INIT,
+        VARIANT_NONE,
+    };
     use crate::registry::LayerRegistry;
+    use crate::WasmTensor;
+
+    fn header(opcode: u8, layer_type: u8, variant: u8, flags: u8, payload_len: u32) -> [u8; 8] {
+        let mut h = [0u8; 8];
+        h[0] = opcode;
+        h[1] = layer_type;
+        h[2] = variant;
+        h[3] = flags;
+        h[4..8].copy_from_slice(&payload_len.to_le_bytes());
+        h
+    }
+
+    fn init_header(layer_type: u8, variant: u8, payload_len: u32) -> PacketHeader {
+        PacketHeader::from_bytes(&header(OP_INIT, layer_type, variant, 0, payload_len)).unwrap()
+    }
 
     #[test]
     fn test_payload_cursor_basic() {
-        // Construct a sample payload:
-        // u32 = 42
-        // f64 = 3.14
-        // bool = true (1)
-        // Option<u32> = Some(100) -> 1, 100
-        // Option<f64> = None -> 0, 0.0
         let mut data = Vec::new();
         data.extend_from_slice(&42u32.to_le_bytes());
         data.extend_from_slice(&3.14f64.to_le_bytes());
@@ -32,10 +44,10 @@ mod tests {
     #[test]
     fn test_packet_header_validate() {
         let mut header_bytes = [0u8; 8];
-        header_bytes[0] = 0x01; // opcode
-        header_bytes[1] = 0x02; // layer_type
-        header_bytes[2] = 0x03; // variant
-        header_bytes[3] = 0x04; // flags
+        header_bytes[0] = 0x01;
+        header_bytes[1] = 0x02;
+        header_bytes[2] = 0x03;
+        header_bytes[3] = 0x04;
         let payload_len: u32 = 12;
         header_bytes[4..8].copy_from_slice(&payload_len.to_le_bytes());
 
@@ -59,33 +71,99 @@ mod tests {
         let mut registry = LayerRegistry::new();
         assert_eq!(registry.total_params(), 0);
 
-        // We can check parameter calculations on initialization and caching.
-        // Let's create a PacketHeader for Linear layer
-        // Linear payload format: id (u32), in_dim (usize/u32), out_dim (usize/u32), bias (bool/u8)
         let mut payload = Vec::new();
         payload.extend_from_slice(&1u32.to_le_bytes()); // id = 1
         payload.extend_from_slice(&10u32.to_le_bytes()); // in_dim = 10
-        payload.extend_from_slice(&5u32.to_le_bytes());  // out_dim = 5
+        payload.extend_from_slice(&5u32.to_le_bytes()); // out_dim = 5
         payload.push(1); // bias = true
 
-        let mut header_bytes = [0u8; 8];
-        header_bytes[0] = crate::protocol::OP_INIT;
-        header_bytes[1] = crate::protocol::LAYER_LINEAR;
-        header_bytes[2] = 0xFF; // variant
-        header_bytes[3] = 0; // flags
-        let payload_len = payload.len() as u32;
-        header_bytes[4..8].copy_from_slice(&payload_len.to_le_bytes());
-
-        let header = PacketHeader::from_bytes(&header_bytes).unwrap();
-        registry.init_layer(&header, &payload).unwrap();
+        let h = init_header(LAYER_LINEAR, VARIANT_NONE, payload.len() as u32);
+        registry.init_layer(&h, &payload).unwrap();
 
         // 10 * 5 (weights) + 5 (bias) = 55 parameters
-        let params = registry.total_params();
-        assert_eq!(params, 55);
+        assert_eq!(registry.total_params(), 55);
 
-        // Delete the layer
-        let destroyed = registry.destroy_layer(1, crate::protocol::LAYER_LINEAR);
+        let destroyed = registry.destroy_layer(1, LAYER_LINEAR);
         assert!(destroyed);
         assert_eq!(registry.total_params(), 0);
+    }
+
+    // ------------------------------------------------------------
+    // GRAPH EXECUTOR TESTS
+    // ------------------------------------------------------------
+    fn build_linear_relu_registry() -> (LayerRegistry, WasmTensor) {
+        let mut reg = LayerRegistry::new();
+
+        // linear id=1 : in=3, out=4, bias=true
+        let mut p = Vec::new();
+        p.extend_from_slice(&1u32.to_le_bytes());
+        p.extend_from_slice(&3u32.to_le_bytes());
+        p.extend_from_slice(&4u32.to_le_bytes());
+        p.push(1);
+        reg.init_layer(&init_header(LAYER_LINEAR, VARIANT_NONE, p.len() as u32), &p)
+            .unwrap();
+
+        // activation id=2 : relu
+        let mut p2 = Vec::new();
+        p2.extend_from_slice(&2u32.to_le_bytes());
+        reg.init_layer(&init_header(LAYER_ACTIVATION, ACT_RELU, p2.len() as u32), &p2)
+            .unwrap();
+
+        let input = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
+        (reg, input)
+    }
+
+    fn push_step(plan: &mut Vec<u8>, layer_type: u8, layer_id: u32, in_slot: u8, out_slot: u8) {
+        plan.push(layer_type);
+        plan.extend_from_slice(&layer_id.to_le_bytes());
+        plan.push(in_slot);
+        plan.push(out_slot);
+    }
+
+    #[test]
+    fn test_run_graph_matches_manual_chain() {
+        let (reg, input) = build_linear_relu_registry();
+
+        // plan: slot0=input -> linear -> slot1 -> relu -> slot2 ; return slot2
+        let mut plan = Vec::new();
+        plan.extend_from_slice(&2u32.to_le_bytes()); // num_steps
+        plan.extend_from_slice(&3u32.to_le_bytes()); // num_slots
+        push_step(&mut plan, LAYER_LINEAR, 1, 0, 1);
+        push_step(&mut plan, LAYER_ACTIVATION, 2, 1, 2);
+        plan.push(2); // out_slot
+
+        let run = reg.run_graph(&plan, &input).unwrap();
+
+        // jalur manual lewat forward_layer (registry sama => bobot sama)
+        let t1 = reg.forward_layer(1, LAYER_LINEAR, &input).unwrap();
+        let t2 = reg.forward_layer(2, LAYER_ACTIVATION, &t1).unwrap();
+
+        assert_eq!(run.to_array(), t2.to_array());
+    }
+
+    #[test]
+    fn test_run_graph_rejects_empty_input_slot() {
+        let (reg, input) = build_linear_relu_registry();
+
+        let mut plan = Vec::new();
+        plan.extend_from_slice(&1u32.to_le_bytes());
+        plan.extend_from_slice(&3u32.to_le_bytes());
+        push_step(&mut plan, LAYER_LINEAR, 1, 2, 1); // in_slot=2 belum terisi
+        plan.push(1);
+
+        assert!(reg.run_graph(&plan, &input).is_err());
+    }
+
+    #[test]
+    fn test_run_graph_rejects_unknown_layer() {
+        let (reg, input) = build_linear_relu_registry();
+
+        let mut plan = Vec::new();
+        plan.extend_from_slice(&1u32.to_le_bytes());
+        plan.extend_from_slice(&2u32.to_le_bytes());
+        push_step(&mut plan, LAYER_LINEAR, 999, 0, 1); // id tidak ada
+        plan.push(1);
+
+        assert!(reg.run_graph(&plan, &input).is_err());
     }
 }


### PR DESCRIPTION
…utor

- Added `OP_RUN_GRAPH` opcode constant.
- Implemented `PayloadCursor` for safe sequential packet deserialization.
- Implemented O(1) total parameters caching in `LayerRegistry` using macros.
- Added a robust Graph Executor (`run_graph`) with two-pass validation in `LayerRegistry`.
- Included 6 unit tests covering payload cursors, packet validation, parameter cache, and run_graph correctness/failure modes.
- Fixed convolution padding configuration for `burn`.