### PR TITLE
Graph Executor v2: 9-Byte Plan with Arity Constraints

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,38 +1,36 @@
 use wasm_bindgen::prelude::*;
-use crate::protocol::PayloadCursor;
+use crate::protocol::{PayloadCursor, LAYER_BINARY};
 use crate::registry::LayerRegistry;
 use crate::WasmTensor;
 
+// Arity = jumlah input sebuah langkah graph. Satu sumber untuk graph + registry.
+pub(crate) const ARITY_UNARY: u8 = 1;
+pub(crate) const ARITY_BINARY: u8 = 2;
+
 // ============================================================
-// COMPILE-ONCE GRAPH EXECUTOR
+// COMPILE-ONCE GRAPH EXECUTOR  (format plan v2: mendukung langkah binary)
 // ============================================================
-// parse + validasi plan DILAKUKAN SEKALI di registry.compileGraph();
-// hasilnya (CompiledGraph) dipegang JS. Loop panas memanggil
-// compiled.run(registry, input) yang TIDAK mem-parse byte lagi, dan
-// tensor intermediate TIDAK menyeberang boundary.
-//
-// run() komposisi penuh dari registry.forward_layer() → 9 cabang dispatch
-// tidak diduplikasi; konsistensi shape/Result otomatis terwarisi.
-//
-// Wire format `plan` (little-endian):
+// Wire format `plan` (little-endian), per langkah 9 byte (fixed stride):
 //   num_steps : u32
 //   num_slots : u32            // 1..=64 ; slot 0 = input eksternal
 //   steps     : ulang num_steps kali ->
-//               { layer_type: u8, layer_id: u32, in_slot: u8, out_slot: u8 }
-//   out_slot  : u8             // slot mana yang dikembalikan
-//
-// ATURAN: steps HARUS urut topologis (sebuah langkah hanya boleh membaca
-// slot yang sudah diisi input atau oleh langkah sebelumnya). Kipas-out
-// (satu slot dibaca banyak langkah) boleh.
+//               { arity:u8, layer_type:u8, layer_id:u32,
+//                 in_slot:u8, in_slot2:u8, out_slot:u8 }
+//   out_slot  : u8
+//   arity 1 -> registry.forward_layer        (in_slot2 = don't-care, tulis 0)
+//   arity 2 -> registry.forward_binary_layer (in_slot + in_slot2)
+// Aturan: steps urut topologis; kipas-out boleh; arity<->type harus cocok.
 // ============================================================
 
 const CG_MAX_SLOTS: u32 = 64;
 
 #[derive(Clone, Copy)]
 struct CompiledStep {
+    arity: u8,
     layer_type: u8,
     layer_id: u32,
     in_slot: u8,
+    in_slot2: u8,
     out_slot: u8,
 }
 
@@ -48,15 +46,16 @@ pub struct CompiledGraph {
 impl CompiledGraph {
     fn read_step(c: &mut PayloadCursor) -> Result<CompiledStep, String> {
         Ok(CompiledStep {
+            arity: c.read_u8()?,
             layer_type: c.read_u8()?,
             layer_id: c.read_u32()?,
             in_slot: c.read_u8()?,
+            in_slot2: c.read_u8()?,
             out_slot: c.read_u8()?,
         })
     }
 
-    /// Parse + validasi SEMUA hal (format, rentang slot, dataflow, keberadaan
-    /// layer) TANPA eksekusi. Gagal = Result::Err rapi, bukan panic.
+    /// Parse + validasi SEMUA hal TANPA eksekusi. Gagal = Result::Err rapi.
     pub(crate) fn build(reg: &LayerRegistry, plan: &[u8]) -> Result<CompiledGraph, String> {
         let mut c = PayloadCursor::new(plan);
         let num_steps = c.read_u32()?;
@@ -77,16 +76,37 @@ impl CompiledGraph {
         for _ in 0..num_steps {
             let s = Self::read_step(&mut c)?;
             let in_slot = s.in_slot as u32;
+            let in_slot2 = s.in_slot2 as u32;
             let out_slot = s.out_slot as u32;
 
-            if in_slot >= num_slots || out_slot >= num_slots {
+            if in_slot >= num_slots || in_slot2 >= num_slots || out_slot >= num_slots {
                 return Err(format!(
                     "compile_graph: slot index out of range (num_slots={})",
                     num_slots
                 ));
             }
-            if (filled >> in_slot) & 1 == 0 {
-                return Err(format!("compile_graph: input slot {} is empty", in_slot));
+            if s.arity == ARITY_BINARY {
+                if s.layer_type != LAYER_BINARY {
+                    return Err(format!(
+                        "compile_graph: arity 2 requires LAYER_BINARY, got 0x{:02X}",
+                        s.layer_type
+                    ));
+                }
+                if (filled >> in_slot) & 1 == 0 {
+                    return Err(format!("compile_graph: input slot {} is empty", in_slot));
+                }
+                if (filled >> in_slot2) & 1 == 0 {
+                    return Err(format!("compile_graph: input slot {} is empty", in_slot2));
+                }
+            } else if s.arity == ARITY_UNARY {
+                if s.layer_type == LAYER_BINARY {
+                    return Err("compile_graph: arity 1 cannot use LAYER_BINARY (needs 2 inputs)".into());
+                }
+                if (filled >> in_slot) & 1 == 0 {
+                    return Err(format!("compile_graph: input slot {} is empty", in_slot));
+                }
+            } else {
+                return Err(format!("compile_graph: invalid arity {} (expected 1 or 2)", s.arity));
             }
             if !reg.layer_exists(s.layer_type, s.layer_id) {
                 return Err(format!(
@@ -113,26 +133,32 @@ impl CompiledGraph {
 // --- API yang dilihat JS ---
 #[wasm_bindgen]
 impl CompiledGraph {
-    /// Jalankan plan yang sudah di-compile di atas `registry` dengan `input`
-    /// di slot 0. TIDAK ada parsing byte di sini — ini jalur panas.
-    /// Kalau sebuah layer di-destroy setelah compile, forward_layer() di bawah
-    /// mengembalikan Err rapi (bukan trap).
+    /// Jalankan plan yang sudah di-compile. TIDAK ada parsing byte di sini.
+    /// Borrow aman: ambil ref input, hasil owned, baru assign ke slot.
     #[wasm_bindgen(js_name = run)]
     pub fn run(
         &self,
         registry: &LayerRegistry,
         input: &WasmTensor,
     ) -> Result<WasmTensor, String> {
-        // invariant: build() menjamin num_slots >= 1 → slots[0] aman.
         let mut slots: Vec<Option<WasmTensor>> = vec![None; self.num_slots as usize];
         slots[0] = Some(input.clone());
 
         for s in &self.steps {
-            let inp = slots[s.in_slot as usize]
-                .as_ref()
-                .ok_or_else(|| format!("run: empty input slot {}", s.in_slot))?;
-            // dispatch yang SUDAH ADA — tidak ada duplikasi 9 cabang.
-            let out = registry.forward_layer(s.layer_id, s.layer_type, inp)?;
+            let out = if s.arity == ARITY_BINARY {
+                let a = slots[s.in_slot as usize]
+                    .as_ref()
+                    .ok_or_else(|| format!("run: empty input slot {}", s.in_slot))?;
+                let b = slots[s.in_slot2 as usize]
+                    .as_ref()
+                    .ok_or_else(|| format!("run: empty input slot {}", s.in_slot2))?;
+                registry.forward_binary_layer(s.layer_id, a, b)?
+            } else {
+                let inp = slots[s.in_slot as usize]
+                    .as_ref()
+                    .ok_or_else(|| format!("run: empty input slot {}", s.in_slot))?;
+                registry.forward_layer(s.layer_id, s.layer_type, inp)?
+            };
             slots[s.out_slot as usize] = Some(out);
         }
 
@@ -141,11 +167,10 @@ impl CompiledGraph {
             .ok_or_else(|| format!("run: empty output slot {}", self.out_slot))
     }
 
-    // Introspeksi murah — berguna untuk assertion di test JS-mu.
     #[wasm_bindgen(js_name = numSteps)]
     pub fn step_count(&self) -> u32 { self.steps.len() as u32 }
     #[wasm_bindgen(js_name = numSlots)]
     pub fn slot_count(&self) -> u32 { self.num_slots }
     #[wasm_bindgen(js_name = outSlot)]
     pub fn output_slot(&self) -> u8 { self.out_slot }
-      }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -414,17 +414,21 @@ const MAX_SLOTS: u32 = 64;
 
 #[derive(Clone, Copy)]
 struct RunStep {
+    arity: u8,        // 1 = unary, 2 = binary
     layer_type: u8,
     layer_id: u32,
     in_slot: u8,
+    in_slot2: u8,     // hanya untuk arity 2
     out_slot: u8,
 }
-
+// 9 byte/step (fixed stride): arity, type, id, in, in2, out
 fn read_run_step(c: &mut PayloadCursor) -> Result<RunStep, String> {
     Ok(RunStep {
+        arity: c.read_u8()?,
         layer_type: c.read_u8()?,
         layer_id: c.read_u32()?,
         in_slot: c.read_u8()?,
+        in_slot2: c.read_u8()?,
         out_slot: c.read_u8()?,
     })
 }
@@ -440,6 +444,7 @@ fn contains_layer(reg: &LayerRegistry, layer_type: u8, layer_id: u32) -> bool {
         LAYER_SHIFT      => reg.shifts.contains_key(&layer_id),
         LAYER_GHOST      => reg.ghosts.contains_key(&layer_id),
         LAYER_SEBLOCK    => reg.seblocks.contains_key(&layer_id),
+        LAYER_BINARY     => reg.binaries.contains_key(&layer_id),
         _ => false,
     }
 }
@@ -450,7 +455,6 @@ fn validate_plan(reg: &LayerRegistry, plan: &[u8]) -> Result<(u32, u32, u8), Str
     let mut c = PayloadCursor::new(plan);
     let num_steps = c.read_u32()?;
     let num_slots = c.read_u32()?;
-
     if num_steps == 0 {
         return Err("run_graph: plan has no steps".into());
     }
@@ -460,21 +464,40 @@ fn validate_plan(reg: &LayerRegistry, plan: &[u8]) -> Result<(u32, u32, u8), Str
             MAX_SLOTS, num_slots
         ));
     }
-
     let mut filled: u64 = 1; // bit 0 = slot 0 (input eksternal) sudah terisi
     for _ in 0..num_steps {
         let s = read_run_step(&mut c)?;
         let in_slot = s.in_slot as u32;
+        let in_slot2 = s.in_slot2 as u32;
         let out_slot = s.out_slot as u32;
-
-        if in_slot >= num_slots || out_slot >= num_slots {
+        if in_slot >= num_slots || in_slot2 >= num_slots || out_slot >= num_slots {
             return Err(format!(
                 "run_graph: slot index out of range (num_slots={})",
                 num_slots
             ));
         }
-        if (filled >> in_slot) & 1 == 0 {
-            return Err(format!("run_graph: input slot {} is empty", in_slot));
+        if s.arity == crate::graph::ARITY_BINARY {
+            if s.layer_type != LAYER_BINARY {
+                return Err(format!(
+                    "run_graph: arity 2 requires LAYER_BINARY, got 0x{:02X}",
+                    s.layer_type
+                ));
+            }
+            if (filled >> in_slot) & 1 == 0 {
+                return Err(format!("run_graph: input slot {} is empty", in_slot));
+            }
+            if (filled >> in_slot2) & 1 == 0 {
+                return Err(format!("run_graph: input slot {} is empty", in_slot2));
+            }
+        } else if s.arity == crate::graph::ARITY_UNARY {
+            if s.layer_type == LAYER_BINARY {
+                return Err("run_graph: arity 1 cannot use LAYER_BINARY (needs 2 inputs)".into());
+            }
+            if (filled >> in_slot) & 1 == 0 {
+                return Err(format!("run_graph: input slot {} is empty", in_slot));
+            }
+        } else {
+            return Err(format!("run_graph: invalid arity {} (expected 1 or 2)", s.arity));
         }
         if !contains_layer(reg, s.layer_type, s.layer_id) {
             return Err(format!(
@@ -482,18 +505,14 @@ fn validate_plan(reg: &LayerRegistry, plan: &[u8]) -> Result<(u32, u32, u8), Str
                 s.layer_type, s.layer_id
             ));
         }
-        filled |= 1u64 << out_slot; // out_slot < 64 dijamin di atas, shift aman
+        filled |= 1u64 << out_slot; // out_slot < 64 dijamin → shift aman
     }
-
     let out_slot = c.read_u8()? as u32;
     if out_slot >= num_slots {
         return Err(format!("run_graph: output slot {} out of range", out_slot));
     }
     if (filled >> out_slot) & 1 == 0 {
-        return Err(format!(
-            "run_graph: output slot {} is never written",
-            out_slot
-        ));
+        return Err(format!("run_graph: output slot {} is never written", out_slot));
     }
     Ok((num_steps, num_slots, out_slot as u8))
 }
@@ -504,25 +523,30 @@ impl LayerRegistry {
     pub fn run_graph(&self, plan: &[u8], input: &WasmTensor) -> Result<WasmTensor, String> {
         // Pass 1: fail-fast, tidak ada eksekusi kalau plan tidak valid.
         let (num_steps, num_slots, out_slot) = validate_plan(self, plan)?;
-
         // Pass 2: eksekusi. Tensor intermediate hidup di Rust saja.
         let mut c = PayloadCursor::new(plan);
         let _ = c.read_u32()?; // num_steps (baca ulang)
         let _ = c.read_u32()?; // num_slots (baca ulang)
-
         let mut slots: Vec<Option<WasmTensor>> = (0..num_slots as usize).map(|_| None).collect();
         slots[0] = Some(input.clone());
-
         for _ in 0..num_steps {
             let s = read_run_step(&mut c)?;
-            let inp = slots[s.in_slot as usize]
-                .as_ref()
-                .ok_or_else(|| format!("run_graph: runtime empty slot {}", s.in_slot))?;
-            // Pakai dispatch yang SUDAH ADA — tidak ada duplikasi 9 cabang.
-            let out = self.forward_layer(s.layer_id, s.layer_type, inp)?;
+            let out = if s.arity == crate::graph::ARITY_BINARY {
+                let a = slots[s.in_slot as usize]
+                    .as_ref()
+                    .ok_or_else(|| format!("run_graph: runtime empty slot {}", s.in_slot))?;
+                let b = slots[s.in_slot2 as usize]
+                    .as_ref()
+                    .ok_or_else(|| format!("run_graph: runtime empty slot {}", s.in_slot2))?;
+                self.forward_binary_layer(s.layer_id, a, b)?
+            } else {
+                let inp = slots[s.in_slot as usize]
+                    .as_ref()
+                    .ok_or_else(|| format!("run_graph: runtime empty slot {}", s.in_slot))?;
+                self.forward_layer(s.layer_id, s.layer_type, inp)?
+            };
             slots[s.out_slot as usize] = Some(out);
         }
-
         slots[out_slot as usize]
             .take()
             .ok_or_else(|| format!("run_graph: runtime empty output slot {}", out_slot))
@@ -547,6 +571,7 @@ impl LayerRegistry {
             LAYER_SHIFT      => self.shifts.contains_key(&layer_id),
             LAYER_GHOST      => self.ghosts.contains_key(&layer_id),
             LAYER_SEBLOCK    => self.seblocks.contains_key(&layer_id),
+            LAYER_BINARY     => self.binaries.contains_key(&layer_id),
             _ => false,
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
     use crate::protocol::{
-        PacketHeader, PayloadCursor, ACT_RELU, LAYER_ACTIVATION, LAYER_LINEAR, OP_INIT,
-        VARIANT_NONE,
+        PacketHeader, PayloadCursor, ACT_RELU, BINARY_ADD, LAYER_ACTIVATION, LAYER_BINARY,
+        LAYER_LINEAR, OP_INIT, VARIANT_NONE,
     };
     use crate::registry::LayerRegistry;
     use crate::WasmTensor;
@@ -21,15 +21,50 @@ mod tests {
         PacketHeader::from_bytes(&header(OP_INIT, layer_type, variant, 0, payload_len)).unwrap()
     }
 
+    // --- plan builder v2 (9 byte/step) ---
+    fn push_unary(
+        plan: &mut Vec<u8>,
+        layer_type: u8,
+        layer_id: u32,
+        in_slot: u8,
+        out_slot: u8,
+    ) {
+        plan.push(1); // arity = unary
+        plan.push(layer_type);
+        plan.extend_from_slice(&layer_id.to_le_bytes());
+        plan.push(in_slot);
+        plan.push(0); // in_slot2 = don't-care
+        plan.push(out_slot);
+    }
+
+    fn push_binary(
+        plan: &mut Vec<u8>,
+        layer_type: u8,
+        layer_id: u32,
+        in_slot: u8,
+        in_slot2: u8,
+        out_slot: u8,
+    ) {
+        plan.push(2); // arity = binary
+        plan.push(layer_type);
+        plan.extend_from_slice(&layer_id.to_le_bytes());
+        plan.push(in_slot);
+        plan.push(in_slot2);
+        plan.push(out_slot);
+    }
+
+    // ------------------------------------------------------------
+    // NON-GRAPH TESTS (direkonstruksi utuh)
+    // ------------------------------------------------------------
     #[test]
     fn test_payload_cursor_basic() {
         let mut data = Vec::new();
         data.extend_from_slice(&42u32.to_le_bytes());
         data.extend_from_slice(&3.14f64.to_le_bytes());
-        data.push(1); // true
-        data.push(1); // Some
+        data.push(1);
+        data.push(1);
         data.extend_from_slice(&100u32.to_le_bytes());
-        data.push(0); // None
+        data.push(0);
         data.extend_from_slice(&0.0f64.to_le_bytes());
 
         let mut cursor = PayloadCursor::new(&data);
@@ -72,15 +107,13 @@ mod tests {
         assert_eq!(registry.total_params(), 0);
 
         let mut payload = Vec::new();
-        payload.extend_from_slice(&1u32.to_le_bytes()); // id = 1
-        payload.extend_from_slice(&10u32.to_le_bytes()); // in_dim = 10
-        payload.extend_from_slice(&5u32.to_le_bytes()); // out_dim = 5
-        payload.push(1); // bias = true
+        payload.extend_from_slice(&1u32.to_le_bytes());
+        payload.extend_from_slice(&10u32.to_le_bytes());
+        payload.extend_from_slice(&5u32.to_le_bytes());
+        payload.push(1);
 
         let h = init_header(LAYER_LINEAR, VARIANT_NONE, payload.len() as u32);
         registry.init_layer(&h, &payload).unwrap();
-
-        // 10 * 5 (weights) + 5 (bias) = 55 parameters
         assert_eq!(registry.total_params(), 55);
 
         let destroyed = registry.destroy_layer(1, LAYER_LINEAR);
@@ -89,12 +122,11 @@ mod tests {
     }
 
     // ------------------------------------------------------------
-    // GRAPH EXECUTOR TESTS
+    // GRAPH TESTS — unary (di-adaptasi ke format 9-byte)
     // ------------------------------------------------------------
     fn build_linear_relu_registry() -> (LayerRegistry, WasmTensor) {
         let mut reg = LayerRegistry::new();
 
-        // linear id=1 : in=3, out=4, bias=true
         let mut p = Vec::new();
         p.extend_from_slice(&1u32.to_le_bytes());
         p.extend_from_slice(&3u32.to_le_bytes());
@@ -103,7 +135,6 @@ mod tests {
         reg.init_layer(&init_header(LAYER_LINEAR, VARIANT_NONE, p.len() as u32), &p)
             .unwrap();
 
-        // activation id=2 : relu
         let mut p2 = Vec::new();
         p2.extend_from_slice(&2u32.to_le_bytes());
         reg.init_layer(&init_header(LAYER_ACTIVATION, ACT_RELU, p2.len() as u32), &p2)
@@ -113,31 +144,20 @@ mod tests {
         (reg, input)
     }
 
-    fn push_step(plan: &mut Vec<u8>, layer_type: u8, layer_id: u32, in_slot: u8, out_slot: u8) {
-        plan.push(layer_type);
-        plan.extend_from_slice(&layer_id.to_le_bytes());
-        plan.push(in_slot);
-        plan.push(out_slot);
-    }
-
     #[test]
     fn test_run_graph_matches_manual_chain() {
         let (reg, input) = build_linear_relu_registry();
 
-        // plan: slot0=input -> linear -> slot1 -> relu -> slot2 ; return slot2
         let mut plan = Vec::new();
-        plan.extend_from_slice(&2u32.to_le_bytes()); // num_steps
-        plan.extend_from_slice(&3u32.to_le_bytes()); // num_slots
-        push_step(&mut plan, LAYER_LINEAR, 1, 0, 1);
-        push_step(&mut plan, LAYER_ACTIVATION, 2, 1, 2);
-        plan.push(2); // out_slot
+        plan.extend_from_slice(&2u32.to_le_bytes());
+        plan.extend_from_slice(&3u32.to_le_bytes());
+        push_unary(&mut plan, LAYER_LINEAR, 1, 0, 1);
+        push_unary(&mut plan, LAYER_ACTIVATION, 2, 1, 2);
+        plan.push(2);
 
         let run = reg.run_graph(&plan, &input).unwrap();
-
-        // jalur manual lewat forward_layer (registry sama => bobot sama)
         let t1 = reg.forward_layer(1, LAYER_LINEAR, &input).unwrap();
         let t2 = reg.forward_layer(2, LAYER_ACTIVATION, &t1).unwrap();
-
         assert_eq!(run.to_array(), t2.to_array());
     }
 
@@ -148,9 +168,8 @@ mod tests {
         let mut plan = Vec::new();
         plan.extend_from_slice(&1u32.to_le_bytes());
         plan.extend_from_slice(&3u32.to_le_bytes());
-        push_step(&mut plan, LAYER_LINEAR, 1, 2, 1); // in_slot=2 belum terisi
+        push_unary(&mut plan, LAYER_LINEAR, 1, 2, 1); // in_slot 2 kosong
         plan.push(1);
-
         assert!(reg.run_graph(&plan, &input).is_err());
     }
 
@@ -161,9 +180,81 @@ mod tests {
         let mut plan = Vec::new();
         plan.extend_from_slice(&1u32.to_le_bytes());
         plan.extend_from_slice(&2u32.to_le_bytes());
-        push_step(&mut plan, LAYER_LINEAR, 999, 0, 1); // id tidak ada
+        push_unary(&mut plan, LAYER_LINEAR, 999, 0, 1); // id tidak ada
         plan.push(1);
-
         assert!(reg.run_graph(&plan, &input).is_err());
+    }
+
+    // ------------------------------------------------------------
+    // GRAPH TESTS — binary (BARU): dua cabang linear di-add
+    // ------------------------------------------------------------
+    fn build_binary_registry() -> (LayerRegistry, WasmTensor) {
+        let mut reg = LayerRegistry::new();
+
+        // linear id=1 (in3,out4,bias)
+        let mut p1 = Vec::new();
+        p1.extend_from_slice(&1u32.to_le_bytes());
+        p1.extend_from_slice(&3u32.to_le_bytes());
+        p1.extend_from_slice(&4u32.to_le_bytes());
+        p1.push(1);
+        reg.init_layer(&init_header(LAYER_LINEAR, VARIANT_NONE, p1.len() as u32), &p1)
+            .unwrap();
+
+        // linear id=2 (in3,out4,bias)
+        let mut p2 = Vec::new();
+        p2.extend_from_slice(&2u32.to_le_bytes());
+        p2.extend_from_slice(&3u32.to_le_bytes());
+        p2.extend_from_slice(&4u32.to_le_bytes());
+        p2.push(1);
+        reg.init_layer(&init_header(LAYER_LINEAR, VARIANT_NONE, p2.len() as u32), &p2)
+            .unwrap();
+
+        // binary add id=3 (dim don't-care = 0)
+        let mut pb = Vec::new();
+        pb.extend_from_slice(&3u32.to_le_bytes());
+        pb.extend_from_slice(&0u32.to_le_bytes());
+        reg.init_layer(&init_header(LAYER_BINARY, BINARY_ADD, pb.len() as u32), &pb)
+            .unwrap();
+
+        let input = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
+        (reg, input)
+    }
+
+    fn binary_plan() -> Vec<u8> {
+        // slot0=input -> linear1 -> slot1 ; slot0 -> linear2 -> slot2 ;
+        // add(slot1,slot2) -> slot3 ; return slot3
+        let mut plan = Vec::new();
+        plan.extend_from_slice(&3u32.to_le_bytes());
+        plan.extend_from_slice(&4u32.to_le_bytes());
+        push_unary(&mut plan, LAYER_LINEAR, 1, 0, 1);
+        push_unary(&mut plan, LAYER_LINEAR, 2, 0, 2);
+        push_binary(&mut plan, LAYER_BINARY, 3, 1, 2, 3);
+        plan.push(3);
+        plan
+    }
+
+    fn binary_manual(reg: &LayerRegistry, input: &WasmTensor) -> Vec<f32> {
+        let t1 = reg.forward_layer(1, LAYER_LINEAR, input).unwrap();
+        let t2 = reg.forward_layer(2, LAYER_LINEAR, input).unwrap();
+        let t3 = reg.forward_binary_layer(3, &t1, &t2).unwrap();
+        t3.to_array()
+    }
+
+    #[test]
+    fn test_run_graph_binary_add() {
+        let (reg, input) = build_binary_registry();
+        let run = reg.run_graph(&binary_plan(), &input).unwrap();
+        assert_eq!(run.to_array(), binary_manual(&reg, &input));
+    }
+
+    #[test]
+    fn test_compile_graph_binary_add() {
+        let (reg, input) = build_binary_registry();
+        let compiled = reg.compile_graph(&binary_plan()).unwrap();
+        assert_eq!(compiled.step_count(), 3);
+        assert_eq!(compiled.slot_count(), 4);
+        assert_eq!(compiled.output_slot(), 3);
+        let run = compiled.run(&reg, &input).unwrap();
+        assert_eq!(run.to_array(), binary_manual(&reg, &input));
     }
 }


### PR DESCRIPTION
Update graph executor and registry to support a 9-byte fixed-stride plan layout with arity validation.

---
*PR created automatically by Jules for task [1554878858110158205](https://jules.google.com/task/1554878858110158205) started by @Ahmadfauzi34*