### PR TITLE
Implement float-bridge M1 for WasmEmbedding and WasmConv

### DIFF
--- a/src/layers/conv.rs
+++ b/src/layers/conv.rs
@@ -154,3 +154,96 @@ impl WasmConv {
         Ok(bytes)
     }
 }
+
+// ============================================================
+// FLOAT-BRIDGE (M1) — conv. Record per variant = { weight: Param<TD>, bias: Option<Param<T1>> }.
+// D = 3 (conv1d) atau 4 (conv2d / transpose2d). Helper generic supaya rank statis & aman.
+// ============================================================
+fn push_param<B: Backend, const D: usize>(
+    p: &burn::module::Param<Tensor<B, D>>,
+    out: &mut Vec<f32>,
+) -> Result<(), String> {
+    let t = <Tensor<B, D> as Clone>::clone(p).into_data();
+    out.extend(
+        t.as_slice::<f32>()
+            .map_err(|_| "getWeightsFlat: conv param not f32".to_string())?,
+    );
+    Ok(())
+}
+
+fn set_conv_param<B: Backend, const D: usize>(
+    weight: &mut burn::module::Param<Tensor<B, D>>,
+    bias: &mut Option<burn::module::Param<Tensor<B, 1>>>,
+    data: &[f32],
+) -> Result<(), String> {
+    let wd = weight.dims(); // [usize; D]
+    let wlen = wd.iter().product::<usize>();
+    let has_bias = bias.is_some();
+    let blen = if has_bias {
+        bias.as_ref().unwrap().dims().iter().product::<usize>()
+    } else {
+        0
+    };
+    if data.len() != wlen + blen {
+        return Err(format!(
+            "setWeightsFlat: conv expected {} floats (weight{}), got {}",
+            wlen + blen,
+            if has_bias { "+bias" } else { "" },
+            data.len()
+        ));
+    }
+    let device: <B as Backend>::Device = Default::default();
+    *weight = burn::module::Param::from_data(
+        burn::tensor::TensorData::new(data[..wlen].to_vec(), wd),
+        &device,
+    );
+    if has_bias {
+        *bias = Some(burn::module::Param::from_data(
+            burn::tensor::TensorData::new(data[wlen..].to_vec(), [blen]),
+            &device,
+        ));
+    }
+    Ok(())
+}
+
+#[wasm_bindgen]
+impl WasmConv {
+    #[wasm_bindgen(js_name = getWeightsFlat)]
+    pub fn get_weights_flat(&self) -> Result<Vec<f32>, String> {
+        let rec = self.inner.clone().into_record();
+        let mut out = Vec::new();
+        match rec {
+            ConvolutionRecord::Conv1d(r) => { // TITIK API: nama record
+                push_param::<WasmBackend, 3>(&r.weight, &mut out)?;
+                if let Some(b) = &r.bias { push_param::<WasmBackend, 1>(b, &mut out)?; }
+            }
+            ConvolutionRecord::Conv2d(r) => {
+                push_param::<WasmBackend, 4>(&r.weight, &mut out)?;
+                if let Some(b) = &r.bias { push_param::<WasmBackend, 1>(b, &mut out)?; }
+            }
+            ConvolutionRecord::ConvTranspose2d(r) => {
+                push_param::<WasmBackend, 4>(&r.weight, &mut out)?;
+                if let Some(b) = &r.bias { push_param::<WasmBackend, 1>(b, &mut out)?; }
+            }
+        }
+        Ok(out)
+    }
+
+    #[wasm_bindgen(js_name = setWeightsFlat)]
+    pub fn set_weights_flat(&mut self, data: &[f32]) -> Result<(), String> {
+        let mut rec = self.inner.clone().into_record();
+        match &mut rec {
+            ConvolutionRecord::Conv1d(r) => {
+                set_conv_param::<WasmBackend, 3>(&mut r.weight, &mut r.bias, data)?;
+            }
+            ConvolutionRecord::Conv2d(r) => {
+                set_conv_param::<WasmBackend, 4>(&mut r.weight, &mut r.bias, data)?;
+            }
+            ConvolutionRecord::ConvTranspose2d(r) => {
+                set_conv_param::<WasmBackend, 4>(&mut r.weight, &mut r.bias, data)?;
+            }
+        }
+        self.inner = self.inner.clone().load_record(rec);
+        Ok(())
+    }
+}

--- a/src/layers/conv.rs
+++ b/src/layers/conv.rs
@@ -247,3 +247,40 @@ impl WasmConv {
         Ok(())
     }
 }
+
+// ============================================================
+// WEIGHT LAYOUT (M2) — conv. Mirror urutan getWeightsFlat per variant.
+// ============================================================
+fn push_conv_segs<B: Backend, const D: usize>(
+    weight: &burn::module::Param<Tensor<B, D>>,
+    bias: &Option<burn::module::Param<Tensor<B, 1>>>,
+    segs: &mut Vec<(&'static str, usize)>,
+) {
+    segs.push(("weight", weight.dims().iter().product::<usize>()));
+    if let Some(b) = bias {
+        segs.push(("bias", b.dims().iter().product::<usize>()));
+    }
+}
+
+impl WasmConv {
+    pub fn weight_segs(&self) -> Vec<(&'static str, usize)> {
+        let rec = self.inner.clone().into_record();
+        let mut segs = Vec::new();
+        match rec {
+            ConvolutionRecord::Conv1d(r) => { // TITIK API (terbukti di M1)
+                push_conv_segs::<WasmBackend, 3>(&r.weight, &r.bias, &mut segs);
+            }
+            ConvolutionRecord::Conv2d(r) => {
+                push_conv_segs::<WasmBackend, 4>(&r.weight, &r.bias, &mut segs);
+            }
+            ConvolutionRecord::ConvTranspose2d(r) => {
+                push_conv_segs::<WasmBackend, 4>(&r.weight, &r.bias, &mut segs);
+            }
+        }
+        segs
+    }
+
+    pub fn weight_layout(&self) -> String {
+        crate::layers::layout::segs_json(&self.weight_segs())
+    }
+}

--- a/src/layers/embedding.rs
+++ b/src/layers/embedding.rs
@@ -95,3 +95,51 @@ impl WasmEmbedding {
         Ok(bytes)
     }
 }
+
+// ============================================================
+// FLOAT-BRIDGE (M1) — embedding. Record = { weight: Param<T2> } (tanpa bias).
+// ============================================================
+#[wasm_bindgen]
+impl WasmEmbedding {
+    #[wasm_bindgen(js_name = weightDims)]
+    pub fn weight_dims(&self) -> Vec<usize> {
+        let rec = self.inner.clone().into_record();
+        match rec {
+            EmbeddingLayerRecord::Basic(r) => r.weight.dims().to_vec(), // TITIK API: nama record + field
+        }
+    }
+
+    #[wasm_bindgen(js_name = getWeightsFlat)]
+    pub fn get_weights_flat(&self) -> Result<Vec<f32>, String> {
+        let rec = self.inner.clone().into_record();
+        match rec {
+            EmbeddingLayerRecord::Basic(r) => {
+                let w = <Tensor<WasmBackend, 2> as Clone>::clone(&r.weight).into_data();
+                w.as_slice::<f32>()
+                    .map_err(|_| "getWeightsFlat: embedding weight not f32".to_string())
+                    .map(|s| s.to_vec())
+            }
+        }
+    }
+
+    #[wasm_bindgen(js_name = setWeightsFlat)]
+    pub fn set_weights_flat(&mut self, data: &[f32]) -> Result<(), String> {
+        let mut rec = self.inner.clone().into_record();
+        match &mut rec {
+            EmbeddingLayerRecord::Basic(r) => {
+                let wd = r.weight.dims(); // [vocab, d_model]
+                let need = wd[0] * wd[1];
+                if data.len() != need {
+                    return Err(format!("setWeightsFlat: expected {} floats, got {}", need, data.len()));
+                }
+                let device: <WasmBackend as Backend>::Device = Default::default();
+                r.weight = burn::module::Param::from_data(
+                    burn::tensor::TensorData::new(data[..need].to_vec(), wd),
+                    &device,
+                );
+            }
+        }
+        self.inner = self.inner.clone().load_record(rec);
+        Ok(())
+    }
+}

--- a/src/layers/embedding.rs
+++ b/src/layers/embedding.rs
@@ -143,3 +143,21 @@ impl WasmEmbedding {
         Ok(())
     }
 }
+
+// ============================================================
+// WEIGHT LAYOUT (M2) — embedding. Hanya weight (tanpa bias).
+// ============================================================
+impl WasmEmbedding {
+    pub fn weight_segs(&self) -> Vec<(&'static str, usize)> {
+        let rec = self.inner.clone().into_record();
+        match rec {
+            EmbeddingLayerRecord::Basic(r) => { // TITIK API (terbukti di M1)
+                vec![("weight", r.weight.dims().iter().product::<usize>())]
+            }
+        }
+    }
+
+    pub fn weight_layout(&self) -> String {
+        crate::layers::layout::segs_json(&self.weight_segs())
+    }
+}

--- a/src/layers/layout.rs
+++ b/src/layers/layout.rs
@@ -1,0 +1,28 @@
+// ============================================================
+// WEIGHT LAYOUT (M2) — mesin mendeskripsikan bentuk bobotnya sendiri.
+// Tiap layer stateful expose daftar segmen (name, len) yang URUTANNYA
+// PERSIS sama dengan getWeightsFlat(). JS/ES susun vektor kandidat dari
+// layout ini (bukan hardcode offset) -> mixing trainable jadi self-describing.
+//
+// Konvensi: len dihitung dari dims() (== jumlah float yang getWeightsFlat hasilkan),
+// sehingga invariant `Σ len == getWeightsFlat().len()` terjaga secara struktural.
+// Formatter JSON dipakai bersama oleh M1b/M1c nanti (satu sumber, tidak duplikat).
+// ============================================================
+
+/// Serialisasi daftar segmen jadi JSON array: [{"name":"weight","len":6}, ...]
+/// Nama segmen alfanumerik + '.' (mis. "fc1.weight") -> tidak butuh escape.
+pub fn segs_json(segs: &[(&'static str, usize)]) -> String {
+    let mut s = String::from("[");
+    for (i, (name, len)) in segs.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str("{\"name\":\"");
+        s.push_str(name);
+        s.push_str("\",\"len\":");
+        s.push_str(&len.to_string());
+        s.push('}');
+    }
+    s.push(']');
+    s
+}

--- a/src/layers/linear.rs
+++ b/src/layers/linear.rs
@@ -154,3 +154,22 @@ impl WasmLinear {
         Ok(())
     }
 }
+
+// ============================================================
+// WEIGHT LAYOUT (M2) — linear. Mirror urutan getWeightsFlat.
+// ============================================================
+impl WasmLinear {
+    pub fn weight_segs(&self) -> Vec<(&'static str, usize)> {
+        let rec = self.inner.inner.clone().into_record();
+        let wlen = rec.weight.dims().iter().product::<usize>();
+        let mut segs = vec![("weight", wlen)];
+        if let Some(b) = &rec.bias {
+            segs.push(("bias", b.dims().iter().product::<usize>()));
+        }
+        segs
+    }
+
+    pub fn weight_layout(&self) -> String {
+        crate::layers::layout::segs_json(&self.weight_segs())
+    }
+}

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -6,3 +6,4 @@ pub mod embedding;
 pub mod pool;
 pub mod binary;
 pub mod custom;
+pub mod layout;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -396,6 +396,24 @@ impl LayerRegistry {
 }
 
 // ============================================================
+// WEIGHT LAYOUT DISPATCH (M2) — mesin deskripsikan bentuk bobot per layer.
+// JS/ES pakai ini untuk susun vektor kandidat tanpa hardcode offset.
+// Baru LINEAR/CONV/EMBEDDING; tipe lain -> Err eksplisit (bukan panic).
+// ============================================================
+#[wasm_bindgen]
+impl LayerRegistry {
+    #[wasm_bindgen(js_name = weightLayout)]
+    pub fn weight_layout(&self, layer_id: LayerId, layer_type: u8) -> Result<String, String> {
+        match layer_type {
+            LAYER_LINEAR    => Ok(self.linears.get(&layer_id).ok_or("Linear not found")?.weight_layout()),
+            LAYER_CONV      => Ok(self.convs.get(&layer_id).ok_or("Conv not found")?.weight_layout()),
+            LAYER_EMBEDDING => Ok(self.embeddings.get(&layer_id).ok_or("Embedding not found")?.weight_layout()),
+            _ => Err(format!("weightLayout: not yet supported for type 0x{:02X}", layer_type)),
+        }
+    }
+}
+
+// ============================================================
 // GRAPH EXECUTOR — jalankan rantai layer dalam 1 panggilan WASM.
 // Tensor intermediate TIDAK menyeberang boundary (kunci performa "Run").
 //

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -593,11 +593,10 @@ impl LayerRegistry {
     #[wasm_bindgen(js_name = getWeightsFlat)]
     pub fn get_weights_flat(&self, layer_id: LayerId, layer_type: u8) -> Result<Vec<f32>, String> {
         match layer_type {
-            LAYER_LINEAR => self.linears.get(&layer_id).ok_or("Linear not found")?.get_weights_flat(),
-            _ => Err(format!(
-                "getWeightsFlat: not yet supported for type 0x{:02X}",
-                layer_type
-            )),
+            LAYER_LINEAR    => self.linears.get(&layer_id).ok_or("Linear not found")?.get_weights_flat(),
+            LAYER_CONV      => self.convs.get(&layer_id).ok_or("Conv not found")?.get_weights_flat(),
+            LAYER_EMBEDDING => self.embeddings.get(&layer_id).ok_or("Embedding not found")?.get_weights_flat(),
+            _ => Err(format!("getWeightsFlat: not yet supported for type 0x{:02X}", layer_type)),
         }
     }
 
@@ -609,15 +608,10 @@ impl LayerRegistry {
         data: &[f32],
     ) -> Result<(), String> {
         match layer_type {
-            LAYER_LINEAR => self
-                .linears
-                .get_mut(&layer_id)
-                .ok_or("Linear not found")?
-                .set_weights_flat(data),
-            _ => Err(format!(
-                "setWeightsFlat: not yet supported for type 0x{:02X}",
-                layer_type
-            )),
+            LAYER_LINEAR    => self.linears.get_mut(&layer_id).ok_or("Linear not found")?.set_weights_flat(data),
+            LAYER_CONV      => self.convs.get_mut(&layer_id).ok_or("Conv not found")?.set_weights_flat(data),
+            LAYER_EMBEDDING => self.embeddings.get_mut(&layer_id).ok_or("Embedding not found")?.set_weights_flat(data),
+            _ => Err(format!("setWeightsFlat: not yet supported for type 0x{:02X}", layer_type)),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -238,25 +238,21 @@ mod tests {
         assert!(reg.get_weights_flat(1, 0xFE).is_err());
         assert!(reg.set_weights_flat(1, 0xFE, &[]).is_err());
     }
-
-    // ---- JANGKAR M1 BARU: float-bridge embedding & conv ----
     #[test]
     fn float_bridge_embedding_roundtrip_and_affects_forward() {
         let mut reg = LayerRegistry::new();
         let mut p = Vec::new();
-        p.extend_from_slice(&1u32.to_le_bytes()); // id
-        p.extend_from_slice(&3u32.to_le_bytes()); // vocab
-        p.extend_from_slice(&2u32.to_le_bytes()); // d_model
+        p.extend_from_slice(&1u32.to_le_bytes());
+        p.extend_from_slice(&3u32.to_le_bytes());
+        p.extend_from_slice(&2u32.to_le_bytes());
         reg.init_layer(&mk_header(LAYER_EMBEDDING, VARIANT_NONE, p.len()), &p).unwrap();
-
         let w = reg.get_weights_flat(1, LAYER_EMBEDDING).unwrap();
-        assert_eq!(w.len(), 3 * 2); // vocab * d_model, tanpa bias
+        assert_eq!(w.len(), 3 * 2);
         reg.set_weights_flat(1, LAYER_EMBEDDING, &w).unwrap();
         assert_eq!(reg.get_weights_flat(1, LAYER_EMBEDDING).unwrap(), w);
-
         let input = WasmTensor::new(&[0.0, 1.0, 2.0, 0.0], &[1, 4, 1, 1]);
         let out1 = reg.forward_layer(1, LAYER_EMBEDDING, &input).unwrap().to_array();
-        assert_eq!(out1.len(), 4 * 2); // seq * d_model
+        assert_eq!(out1.len(), 4 * 2);
         let w2: Vec<f32> = w.iter().map(|v| v + 1.0).collect();
         reg.set_weights_flat(1, LAYER_EMBEDDING, &w2).unwrap();
         let out2 = reg.forward_layer(1, LAYER_EMBEDDING, &input).unwrap().to_array();
@@ -266,24 +262,64 @@ mod tests {
     fn float_bridge_conv_roundtrip_and_affects_forward() {
         let mut reg = LayerRegistry::new();
         let mut p = Vec::new();
-        p.extend_from_slice(&1u32.to_le_bytes()); // id
-        p.extend_from_slice(&1u32.to_le_bytes()); // in_ch
-        p.extend_from_slice(&1u32.to_le_bytes()); // out_ch
-        p.extend_from_slice(&1u32.to_le_bytes()); // kh
-        p.extend_from_slice(&1u32.to_le_bytes()); // kw
-        for _ in 0..4 { p.push(0); p.extend_from_slice(&0u32.to_le_bytes()); } // sh,sw,ph,pw = None
+        p.extend_from_slice(&1u32.to_le_bytes());
+        p.extend_from_slice(&1u32.to_le_bytes());
+        p.extend_from_slice(&1u32.to_le_bytes());
+        p.extend_from_slice(&1u32.to_le_bytes());
+        p.extend_from_slice(&1u32.to_le_bytes());
+        for _ in 0..4 { p.push(0); p.extend_from_slice(&0u32.to_le_bytes()); }
         reg.init_layer(&mk_header(LAYER_CONV, CONV_CONV2D, p.len()), &p).unwrap();
-
         let w = reg.get_weights_flat(1, LAYER_CONV).unwrap();
-        assert_eq!(w.len(), 1 * 1 * 1 * 1 + 1); // weight(1) + bias(1)
+        assert_eq!(w.len(), 1 * 1 * 1 * 1 + 1);
         reg.set_weights_flat(1, LAYER_CONV, &w).unwrap();
         assert_eq!(reg.get_weights_flat(1, LAYER_CONV).unwrap(), w);
-
         let input = WasmTensor::new(&[1.0, 2.0, 3.0, 4.0], &[1, 1, 2, 2]);
         let out1 = reg.forward_layer(1, LAYER_CONV, &input).unwrap().to_array();
         let w2: Vec<f32> = w.iter().map(|v| v + 1.0).collect();
         reg.set_weights_flat(1, LAYER_CONV, &w2).unwrap();
         let out2 = reg.forward_layer(1, LAYER_CONV, &input).unwrap().to_array();
         assert_ne!(out1, out2);
+    }
+
+    // ---- JANGKAR M2 BARU: weightLayout konsisten dengan getWeightsFlat ----
+    #[test]
+    fn weight_layout_consistent_with_flat() {
+        use crate::layers::linear::WasmLinear;
+        use crate::layers::conv::WasmConv;
+        use crate::layers::embedding::WasmEmbedding;
+        use crate::layers::layout::segs_json;
+
+        fn check(segs: &[(&'static str, usize)], flat_len: usize, json: &str) {
+            let sum: usize = segs.iter().map(|s| s.1).sum();
+            assert_eq!(sum, flat_len, "Σ layout len != getWeightsFlat len");
+            assert!(segs.iter().any(|s| s.0 == "weight"), "wajib ada segmen weight");
+            let expected = segs_json(segs);
+            assert_eq!(json, expected.as_str(), "wrapper json != segs_json(segs)");
+            assert!(json.starts_with('[') && json.ends_with(']'), "json harus array");
+        }
+
+        // linear dengan bias
+        let lin = WasmLinear::new(3, 2, true);
+        let j = lin.weight_layout();
+        check(&lin.weight_segs(), lin.get_weights_flat().unwrap().len(), &j);
+
+        // linear tanpa bias -> segmen bias HARUS absen
+        let lin_nb = WasmLinear::new(3, 2, false);
+        let segs_nb = lin_nb.weight_segs();
+        assert!(!segs_nb.iter().any(|s| s.0 == "bias"), "linear no-bias: segmen bias harus absen");
+        let j_nb = lin_nb.weight_layout();
+        check(&segs_nb, lin_nb.get_weights_flat().unwrap().len(), &j_nb);
+
+        // embedding -> hanya weight
+        let emb = WasmEmbedding::new(3, 2);
+        let segs_e = emb.weight_segs();
+        assert!(!segs_e.iter().any(|s| s.0 == "bias"), "embedding: segmen bias harus absen");
+        let j_e = emb.weight_layout();
+        check(&segs_e, emb.get_weights_flat().unwrap().len(), &j_e);
+
+        // conv2d -> weight + bias
+        let conv = WasmConv::new_conv2d(1, 1, 1, 1, None, None, None, None);
+        let j_c = conv.weight_layout();
+        check(&conv.weight_segs(), conv.get_weights_flat().unwrap().len(), &j_c);
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,7 @@
 mod tests {
     use crate::protocol::{
         PacketHeader, PayloadCursor, OP_INIT, VARIANT_NONE, LAYER_LINEAR, LAYER_ACTIVATION,
-        ACT_RELU, LAYER_BINARY, BINARY_ADD,
+        ACT_RELU, LAYER_BINARY, BINARY_ADD, LAYER_EMBEDDING, LAYER_CONV, CONV_CONV2D,
     };
     use crate::registry::LayerRegistry;
     use crate::WasmTensor;
@@ -11,18 +11,12 @@ mod tests {
     use crate::es::objective::{LinearMseObjective, Objective};
     use crate::es::optimizer::EsOptimizer;
 
-    // ---- helper paket init (seragam untuk semua fixture) ----
     fn mk_header(layer_type: u8, variant: u8, payload_len: usize) -> PacketHeader {
         let mut h = [0u8; 8];
-        h[0] = OP_INIT;
-        h[1] = layer_type;
-        h[2] = variant;
-        h[3] = 0;
+        h[0] = OP_INIT; h[1] = layer_type; h[2] = variant; h[3] = 0;
         h[4..8].copy_from_slice(&(payload_len as u32).to_le_bytes());
         PacketHeader::from_bytes(&h).unwrap()
     }
-
-    // ---- helper plan v2 (9 byte/step) ----
     fn push_unary(plan: &mut Vec<u8>, lt: u8, id: u32, in_slot: u8, out_slot: u8) {
         plan.push(1); plan.push(lt); plan.extend_from_slice(&id.to_le_bytes());
         plan.push(in_slot); plan.push(0); plan.push(out_slot);
@@ -32,16 +26,13 @@ mod tests {
         plan.push(a); plan.push(b); plan.push(out_slot);
     }
 
-    // ============================================================
-    // REKONSTRUKSI JANGKAR LAMA (tidak ada yang hilang)
-    // ============================================================
+    // ---- jangkar lama (direkonstruksi utuh) ----
     #[test]
     fn test_payload_cursor_basic() {
         let mut data = Vec::new();
         data.extend_from_slice(&42u32.to_le_bytes());
         data.extend_from_slice(&3.14f64.to_le_bytes());
-        data.push(1);
-        data.push(1);
+        data.push(1); data.push(1);
         data.extend_from_slice(&100u32.to_le_bytes());
         data.push(0);
         data.extend_from_slice(&0.0f64.to_le_bytes());
@@ -53,22 +44,17 @@ mod tests {
         assert_eq!(c.read_option_f64().unwrap(), None);
         assert_eq!(c.remaining(), 0);
     }
-
     #[test]
     fn test_packet_header_validate() {
         let mut hb = [0u8; 8];
         hb[0] = 0x01; hb[1] = 0x02; hb[2] = 0x03; hb[3] = 0x04;
         hb[4..8].copy_from_slice(&12u32.to_le_bytes());
         let h = PacketHeader::from_bytes(&hb).unwrap();
-        assert_eq!(h.opcode, 0x01);
-        assert_eq!(h.layer_type, 0x02);
-        assert_eq!(h.variant, 0x03);
-        assert_eq!(h.flags, 0x04);
-        assert_eq!(h.payload_len, 12);
+        assert_eq!(h.opcode, 0x01); assert_eq!(h.layer_type, 0x02);
+        assert_eq!(h.variant, 0x03); assert_eq!(h.flags, 0x04); assert_eq!(h.payload_len, 12);
         assert_eq!(h.validate_payload(&vec![0u8; 12]).unwrap().len(), 12);
         assert!(h.validate_payload(&vec![0u8; 10]).is_err());
     }
-
     #[test]
     fn test_layer_registry_param_cache() {
         let mut reg = LayerRegistry::new();
@@ -79,11 +65,10 @@ mod tests {
         p.extend_from_slice(&5u32.to_le_bytes());
         p.push(1);
         reg.init_layer(&mk_header(LAYER_LINEAR, VARIANT_NONE, p.len()), &p).unwrap();
-        assert_eq!(reg.total_params(), 55); // 10*5 + 5
+        assert_eq!(reg.total_params(), 55);
         assert!(reg.destroy_layer(1, LAYER_LINEAR));
         assert_eq!(reg.total_params(), 0);
     }
-
     fn build_linear_relu() -> (LayerRegistry, WasmTensor) {
         let mut reg = LayerRegistry::new();
         let mut p = Vec::new();
@@ -97,7 +82,6 @@ mod tests {
         reg.init_layer(&mk_header(LAYER_ACTIVATION, ACT_RELU, p2.len()), &p2).unwrap();
         (reg, WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]))
     }
-
     #[test]
     fn test_run_graph_unary_matches_manual() {
         let (reg, input) = build_linear_relu();
@@ -112,18 +96,16 @@ mod tests {
         let t2 = reg.forward_layer(2, LAYER_ACTIVATION, &t1).unwrap();
         assert_eq!(run.to_array(), t2.to_array());
     }
-
     #[test]
     fn test_run_graph_rejects_empty_slot() {
         let (reg, input) = build_linear_relu();
         let mut plan = Vec::new();
         plan.extend_from_slice(&1u32.to_le_bytes());
         plan.extend_from_slice(&3u32.to_le_bytes());
-        push_unary(&mut plan, LAYER_LINEAR, 1, 2, 1); // slot 2 kosong
+        push_unary(&mut plan, LAYER_LINEAR, 1, 2, 1);
         plan.push(1);
         assert!(reg.run_graph(&plan, &input).is_err());
     }
-
     #[test]
     fn test_run_graph_rejects_unknown_layer() {
         let (reg, input) = build_linear_relu();
@@ -134,7 +116,6 @@ mod tests {
         plan.push(1);
         assert!(reg.run_graph(&plan, &input).is_err());
     }
-
     fn build_binary() -> (LayerRegistry, WasmTensor) {
         let mut reg = LayerRegistry::new();
         for id in [1u32, 2] {
@@ -166,13 +147,11 @@ mod tests {
         let t2 = reg.forward_layer(2, LAYER_LINEAR, input).unwrap();
         reg.forward_binary_layer(3, &t1, &t2).unwrap().to_array()
     }
-
     #[test]
     fn test_run_graph_binary_add() {
         let (reg, input) = build_binary();
         assert_eq!(reg.run_graph(&binary_plan(), &input).unwrap().to_array(), binary_manual(&reg, &input));
     }
-
     #[test]
     fn test_compile_graph_binary_add() {
         let (reg, input) = build_binary();
@@ -182,35 +161,24 @@ mod tests {
         assert_eq!(c.output_slot(), 3);
         assert_eq!(c.run(&reg, &input).unwrap().to_array(), binary_manual(&reg, &input));
     }
-
-    // ============================================================
-    // JANGKAR BARU — ES (gradient-free): determinisme + fondasi pure
-    // (konvergensi numerik sengaja DITUNDA: butuh ambang yang tidak bisa
-    //  diverifikasi di sini; jangkar yang tepat = saat objective RL nyata masuk)
-    // ============================================================
     #[test]
     fn es_rng_is_deterministic() {
-        let mut a = Rng::new(42);
-        let mut b = Rng::new(42);
+        let mut a = Rng::new(42); let mut b = Rng::new(42);
         let va: Vec<f32> = (0..100).map(|_| a.gaussian()).collect();
         let vb: Vec<f32> = (0..100).map(|_| b.gaussian()).collect();
-        assert_eq!(va, vb); // canary reproducibility
+        assert_eq!(va, vb);
     }
-
     #[test]
     fn es_diag_mean_std_known() {
         let (m, s) = mean_std(&[1.0, 2.0, 3.0, 4.0]);
         assert!((m - 2.5).abs() < 1e-12);
-        assert!((s - 1.1180339887498949).abs() < 1e-9); // std populasi sqrt(1.25)
+        assert!((s - 1.1180339887498949).abs() < 1e-9);
     }
-
     #[test]
     fn es_diag_diversity_identical_is_zero() {
         let cands = vec![vec![1.0, 2.0], vec![1.0, 2.0], vec![1.0, 2.0]];
-        assert_eq!(diversity(&cands), 0.0); // canary collapse-detection
+        assert_eq!(diversity(&cands), 0.0);
     }
-
-    // objective deterministik buatan test: y = 0.5 * x  (in=1, out=1)
     fn make_obj() -> LinearMseObjective {
         LinearMseObjective::new(vec![1.0, 2.0, 3.0, 4.0], vec![0.5, 1.0, 1.5, 2.0], 4, 1, 1)
     }
@@ -227,16 +195,14 @@ mod tests {
         }
         (es.best(), es.report())
     }
-
     #[test]
     fn es_optimizer_is_deterministic_end_to_end() {
         let (b1, r1) = run_es(42);
         let (b2, r2) = run_es(42);
-        assert_eq!(b1.len(), 1);          // best terisi
-        assert_eq!(b1, b2);               // ask/tell/objective/best-tracking deterministik
-        assert_eq!(r1, r2);               // laporan JSON deterministik
+        assert_eq!(b1.len(), 1);
+        assert_eq!(b1, b2);
+        assert_eq!(r1, r2);
     }
-
     #[test]
     fn es_ask_batch_shape_contract() {
         let mut es = EsOptimizer::new(3, 0, 7, Some(8), Some(0.2), Some(0.1));
@@ -244,39 +210,80 @@ mod tests {
         let n = es.batch_size() as usize;
         let d = es.dim() as usize;
         assert!(n > 0);
-        assert_eq!(flat.len(), n * d);    // kontrak: flat = kandidat * dim
+        assert_eq!(flat.len(), n * d);
     }
-
-    // ============================================================
-    // JANGKAR BARU — FLOAT-BRIDGE: kabel ES↔graph (baca/tulis bobot float)
-    // ============================================================
     #[test]
     fn float_bridge_linear_roundtrip_and_affects_forward() {
         let mut reg = LayerRegistry::new();
         let mut p = Vec::new();
-        p.extend_from_slice(&1u32.to_le_bytes()); // id
-        p.extend_from_slice(&3u32.to_le_bytes()); // in
-        p.extend_from_slice(&2u32.to_le_bytes()); // out
-        p.push(1);                                // bias
+        p.extend_from_slice(&1u32.to_le_bytes());
+        p.extend_from_slice(&3u32.to_le_bytes());
+        p.extend_from_slice(&2u32.to_le_bytes());
+        p.push(1);
         reg.init_layer(&mk_header(LAYER_LINEAR, VARIANT_NONE, p.len()), &p).unwrap();
-
         let w = reg.get_weights_flat(1, LAYER_LINEAR).unwrap();
-        assert_eq!(w.len(), 3 * 2 + 2);                       // layout: weight + bias
+        assert_eq!(w.len(), 3 * 2 + 2);
         reg.set_weights_flat(1, LAYER_LINEAR, &w).unwrap();
-        assert_eq!(reg.get_weights_flat(1, LAYER_LINEAR).unwrap(), w); // roundtrip bit-identik
-
+        assert_eq!(reg.get_weights_flat(1, LAYER_LINEAR).unwrap(), w);
         let input = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
         let out1 = reg.forward_layer(1, LAYER_LINEAR, &input).unwrap().to_array();
         let w2: Vec<f32> = w.iter().map(|v| v + 1.0).collect();
         reg.set_weights_flat(1, LAYER_LINEAR, &w2).unwrap();
         let out2 = reg.forward_layer(1, LAYER_LINEAR, &input).unwrap().to_array();
-        assert_ne!(out1, out2);                               // set benar-benar mengubah forward
+        assert_ne!(out1, out2);
     }
-
     #[test]
     fn float_bridge_unknown_type_is_err() {
         let mut reg = LayerRegistry::new();
-        assert!(reg.get_weights_flat(1, 0xFE).is_err());      // bukan panic
+        assert!(reg.get_weights_flat(1, 0xFE).is_err());
         assert!(reg.set_weights_flat(1, 0xFE, &[]).is_err());
+    }
+
+    // ---- JANGKAR M1 BARU: float-bridge embedding & conv ----
+    #[test]
+    fn float_bridge_embedding_roundtrip_and_affects_forward() {
+        let mut reg = LayerRegistry::new();
+        let mut p = Vec::new();
+        p.extend_from_slice(&1u32.to_le_bytes()); // id
+        p.extend_from_slice(&3u32.to_le_bytes()); // vocab
+        p.extend_from_slice(&2u32.to_le_bytes()); // d_model
+        reg.init_layer(&mk_header(LAYER_EMBEDDING, VARIANT_NONE, p.len()), &p).unwrap();
+
+        let w = reg.get_weights_flat(1, LAYER_EMBEDDING).unwrap();
+        assert_eq!(w.len(), 3 * 2); // vocab * d_model, tanpa bias
+        reg.set_weights_flat(1, LAYER_EMBEDDING, &w).unwrap();
+        assert_eq!(reg.get_weights_flat(1, LAYER_EMBEDDING).unwrap(), w);
+
+        let input = WasmTensor::new(&[0.0, 1.0, 2.0, 0.0], &[1, 4, 1, 1]);
+        let out1 = reg.forward_layer(1, LAYER_EMBEDDING, &input).unwrap().to_array();
+        assert_eq!(out1.len(), 4 * 2); // seq * d_model
+        let w2: Vec<f32> = w.iter().map(|v| v + 1.0).collect();
+        reg.set_weights_flat(1, LAYER_EMBEDDING, &w2).unwrap();
+        let out2 = reg.forward_layer(1, LAYER_EMBEDDING, &input).unwrap().to_array();
+        assert_ne!(out1, out2);
+    }
+    #[test]
+    fn float_bridge_conv_roundtrip_and_affects_forward() {
+        let mut reg = LayerRegistry::new();
+        let mut p = Vec::new();
+        p.extend_from_slice(&1u32.to_le_bytes()); // id
+        p.extend_from_slice(&1u32.to_le_bytes()); // in_ch
+        p.extend_from_slice(&1u32.to_le_bytes()); // out_ch
+        p.extend_from_slice(&1u32.to_le_bytes()); // kh
+        p.extend_from_slice(&1u32.to_le_bytes()); // kw
+        for _ in 0..4 { p.push(0); p.extend_from_slice(&0u32.to_le_bytes()); } // sh,sw,ph,pw = None
+        reg.init_layer(&mk_header(LAYER_CONV, CONV_CONV2D, p.len()), &p).unwrap();
+
+        let w = reg.get_weights_flat(1, LAYER_CONV).unwrap();
+        assert_eq!(w.len(), 1 * 1 * 1 * 1 + 1); // weight(1) + bias(1)
+        reg.set_weights_flat(1, LAYER_CONV, &w).unwrap();
+        assert_eq!(reg.get_weights_flat(1, LAYER_CONV).unwrap(), w);
+
+        let input = WasmTensor::new(&[1.0, 2.0, 3.0, 4.0], &[1, 1, 2, 2]);
+        let out1 = reg.forward_layer(1, LAYER_CONV, &input).unwrap().to_array();
+        let w2: Vec<f32> = w.iter().map(|v| v + 1.0).collect();
+        reg.set_weights_flat(1, LAYER_CONV, &w2).unwrap();
+        let out2 = reg.forward_layer(1, LAYER_CONV, &input).unwrap().to_array();
+        assert_ne!(out1, out2);
     }
 }


### PR DESCRIPTION
This commit implements the float-bridge (M1) capabilities for Embedding and Convolution layers in the Wasm registry, matching the exact specifications and templates provided. All tests are verified green.

---
*PR created automatically by Jules for task [8623960189615540792](https://jules.google.com/task/8623960189615540792) started by @Ahmadfauzi34*