### PR TITLE
Harden ES data-shape invariants

### DIFF
--- a/src/es/diag.rs
+++ b/src/es/diag.rs
@@ -6,33 +6,58 @@ pub fn mean_std(v: &[f64]) -> (f64, f64) {
         return (f64::NAN, f64::NAN);
     }
     let mut s = 0.0f64;
-    for &x in v { s += x; }
+    for &x in v {
+        s += x;
+    }
     let m = s / n as f64;
     let mut var = 0.0f64;
-    for &x in v { let d = x - m; var += d * d; }
+    for &x in v {
+        let d = x - m;
+        var += d * d;
+    }
     (m, (var / n as f64).sqrt())
 }
 
 /// Rata-rata std per-dimensi antar kandidat. Mengukur "collapse" populasi.
+///
+/// Populasi ragged bukan state yang valid untuk ES. Alih-alih indexing panic,
+/// kembalikan NaN agar lapisan laporan dapat merepresentasikannya sebagai null.
 pub fn diversity(cands: &[Vec<f32>]) -> f64 {
     let n = cands.len();
-    if n < 2 { return 0.0; }
+    if n < 2 {
+        return 0.0;
+    }
     let dim = cands[0].len();
-    if dim == 0 { return 0.0; }
+    if dim == 0 {
+        return 0.0;
+    }
+    if cands.iter().any(|c| c.len() != dim) {
+        return f64::NAN;
+    }
+
     let mut sum_std = 0.0f64;
     for d in 0..dim {
         let mut s = 0.0f64;
-        for c in cands { s += c[d] as f64; }
+        for c in cands {
+            s += c[d] as f64;
+        }
         let m = s / n as f64;
         let mut var = 0.0f64;
-        for c in cands { let diff = c[d] as f64 - m; var += diff * diff; }
+        for c in cands {
+            let diff = c[d] as f64 - m;
+            var += diff * diff;
+        }
         sum_std += (var / n as f64).sqrt();
     }
     sum_std / dim as f64
 }
 
 fn fjson(f: f64) -> String {
-    if f.is_finite() { format!("{f}") } else { "null".into() }
+    if f.is_finite() {
+        format!("{f}")
+    } else {
+        "null".into()
+    }
 }
 
 pub struct EsReport {
@@ -76,10 +101,14 @@ impl EsReport {
         s.push_str(&format!("\"best_norm\":{},", fjson(self.best_norm)));
         s.push_str("\"flags\":[");
         for (i, f) in self.flags.iter().enumerate() {
-            if i > 0 { s.push(','); }
-            s.push('"'); s.push_str(f); s.push('"');
+            if i > 0 {
+                s.push(',');
+            }
+            s.push('"');
+            s.push_str(f);
+            s.push('"');
         }
         s.push_str("]}");
         s
     }
-                   }
+}

--- a/src/es/invariant_tests.rs
+++ b/src/es/invariant_tests.rs
@@ -1,0 +1,38 @@
+use super::diag::diversity;
+use super::objective::{LinearMseObjective, Objective};
+
+#[test]
+fn linear_mse_valid_shape_preserves_fitness() {
+    let obj = LinearMseObjective::new(vec![1.0, 2.0], vec![5.0], 1, 2, 1);
+    assert_eq!(obj.fitness(&[1.0, 2.0]), 0.0);
+}
+
+#[test]
+fn linear_mse_rejects_short_x_without_panicking() {
+    let obj = LinearMseObjective::new(vec![1.0], vec![5.0], 1, 2, 1);
+    assert_eq!(obj.fitness(&[1.0, 2.0]), f64::NEG_INFINITY);
+}
+
+#[test]
+fn linear_mse_rejects_short_y_without_panicking() {
+    let obj = LinearMseObjective::new(vec![1.0, 2.0], vec![], 1, 2, 1);
+    assert_eq!(obj.fitness(&[1.0, 2.0]), f64::NEG_INFINITY);
+}
+
+#[test]
+fn linear_mse_rejects_dimension_overflow_without_panicking() {
+    let obj = LinearMseObjective::new(vec![], vec![], usize::MAX, 2, 2);
+    assert_eq!(obj.fitness(&[0.0; 4]), f64::NEG_INFINITY);
+}
+
+#[test]
+fn diversity_rejects_ragged_population_without_panicking() {
+    let cands = vec![vec![1.0, 2.0], vec![3.0]];
+    assert!(diversity(&cands).is_nan());
+}
+
+#[test]
+fn diversity_rectangular_population_remains_finite() {
+    let cands = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+    assert!(diversity(&cands).is_finite());
+}

--- a/src/es/mod.rs
+++ b/src/es/mod.rs
@@ -3,3 +3,6 @@ pub mod diag;
 pub mod strategy;
 pub mod objective;
 pub mod optimizer;
+
+#[cfg(test)]
+mod invariant_tests;

--- a/src/es/objective.rs
+++ b/src/es/objective.rs
@@ -9,8 +9,8 @@ pub trait Objective {
 
 /// y = X * W ; fitness = -mean((pred - y)^2). Plain Rust, deterministik, tanpa burn.
 pub struct LinearMseObjective {
-    pub x: Vec<f32>,          // [n * in_dim]
-    pub y: Vec<f32>,          // [n * out_dim]
+    pub x: Vec<f32>, // [n * in_dim]
+    pub y: Vec<f32>, // [n * out_dim]
     pub n: usize,
     pub in_dim: usize,
     pub out_dim: usize,
@@ -18,30 +18,54 @@ pub struct LinearMseObjective {
 
 impl LinearMseObjective {
     pub fn new(x: Vec<f32>, y: Vec<f32>, n: usize, in_dim: usize, out_dim: usize) -> Self {
-        Self { x, y, n, in_dim, out_dim }
+        Self {
+            x,
+            y,
+            n,
+            in_dim,
+            out_dim,
+        }
+    }
+
+    fn expected_lengths(&self) -> Option<(usize, usize, usize)> {
+        let x_len = self.n.checked_mul(self.in_dim)?;
+        let y_len = self.n.checked_mul(self.out_dim)?;
+        let w_len = self.in_dim.checked_mul(self.out_dim)?;
+        Some((x_len, y_len, w_len))
     }
 }
 
 impl Objective for LinearMseObjective {
     fn fitness(&self, w: &[f32]) -> f64 {
-        if w.len() != self.in_dim * self.out_dim {
+        let Some((expected_x, expected_y, expected_w)) = self.expected_lengths() else {
+            return f64::NEG_INFINITY;
+        };
+
+        if self.x.len() != expected_x || self.y.len() != expected_y || w.len() != expected_w {
             return f64::NEG_INFINITY;
         }
+
+        let Some(count) = self.n.checked_mul(self.out_dim) else {
+            return f64::NEG_INFINITY;
+        };
+        if count == 0 {
+            return f64::NEG_INFINITY;
+        }
+
         let mut mse = 0.0f64;
-        let mut count = 0usize;
         for i in 0..self.n {
             for o in 0..self.out_dim {
                 let mut pred = 0.0f64;
                 for k in 0..self.in_dim {
-                    pred += self.x[i * self.in_dim + k] as f64 * w[k * self.out_dim + o] as f64;
+                    pred += self.x[i * self.in_dim + k] as f64
+                        * w[k * self.out_dim + o] as f64;
                 }
                 let target = self.y[i * self.out_dim + o] as f64;
                 let err = pred - target;
                 mse += err * err;
-                count += 1;
             }
         }
-        if count == 0 { return f64::NEG_INFINITY; }
+
         -(mse / count as f64) // negasi: ES memaksimalkan
     }
-              }
+}


### PR DESCRIPTION
## Tujuan
Memperkuat jalur ES yang sudah ada tanpa menambah fitur baru dan tanpa bergantung pada PR #14.

## Perubahan
- `LinearMseObjective::fitness` memvalidasi panjang X/Y/W terhadap metadata sebelum indexing
- gunakan checked multiplication untuk menolak overflow dimensi sebagai fitness invalid (`-inf`)
- `diversity` mendeteksi populasi ragged sebelum indexing dan mengembalikan `NaN` diagnostic
- tambah 6 regression tests untuk valid path, short X, short Y, overflow metadata, ragged population, dan rectangular population

## Invariant yang dipertahankan
- input valid menghasilkan rumus MSE yang sama
- ES tetap memaksimalkan negative-MSE
- rectangular candidate populations dihitung seperti sebelumnya
- malformed objective tidak mengubah state optimizer; hanya menghasilkan fitness invalid

## Independensi
Branch ini dibuat langsung dari `main` (`8cd0b31`) dan tidak mengandung perubahan dari PR #14 atau PR lama #1–#13.