### PR TITLE
Unify protocol read invariants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod es;
 pub mod graph;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod protocol_invariant_tests;
 
 pub type WasmBackend = burn_ndarray::NdArray<f32>;
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -291,8 +291,16 @@ impl<'a> PayloadCursor<'a> {
 // HELPER: read/write multi-byte dari payload
 // ============================================================
 
+#[inline]
+fn checked_end(offset: usize, width: usize, label: &str) -> Result<usize, String> {
+    offset
+        .checked_add(width)
+        .ok_or_else(|| format!("{} offset overflow", label))
+}
+
 pub fn read_u32(payload: &[u8], offset: usize) -> Result<u32, String> {
-    if offset + 4 > payload.len() {
+    let end = checked_end(offset, 4, "read_u32")?;
+    if end > payload.len() {
         return Err("read_u32 out of bounds".into());
     }
     Ok(u32::from_le_bytes([
@@ -304,7 +312,8 @@ pub fn read_u32(payload: &[u8], offset: usize) -> Result<u32, String> {
 }
 
 pub fn read_f64(payload: &[u8], offset: usize) -> Result<f64, String> {
-    if offset + 8 > payload.len() {
+    let end = checked_end(offset, 8, "read_f64")?;
+    if end > payload.len() {
         return Err("read_f64 out of bounds".into());
     }
     Ok(f64::from_le_bytes([
@@ -325,23 +334,21 @@ pub fn read_bool(payload: &[u8], offset: usize) -> Result<bool, String> {
 }
 
 pub fn read_option_u32(payload: &[u8], offset: usize) -> Result<Option<u32>, String> {
-    if offset >= payload.len() {
-        return Err("read_option out of bounds".into());
+    let end = checked_end(offset, 5, "read_option_u32")?;
+    if end > payload.len() {
+        return Err("read_option_u32 out of bounds".into());
     }
-    if payload[offset] == 0 {
-        Ok(None)
-    } else {
-        read_u32(payload, offset + 1).map(Some)
-    }
+    let present = payload[offset] != 0;
+    let value = read_u32(payload, offset + 1)?;
+    Ok(if present { Some(value) } else { None })
 }
 
 pub fn read_option_f64(payload: &[u8], offset: usize) -> Result<Option<f64>, String> {
-    if offset >= payload.len() {
-        return Err("read_option out of bounds".into());
+    let end = checked_end(offset, 9, "read_option_f64")?;
+    if end > payload.len() {
+        return Err("read_option_f64 out of bounds".into());
     }
-    if payload[offset] == 0 {
-        Ok(None)
-    } else {
-        read_f64(payload, offset + 1).map(Some)
-    }
+    let present = payload[offset] != 0;
+    let value = read_f64(payload, offset + 1)?;
+    Ok(if present { Some(value) } else { None })
 }

--- a/src/protocol_invariant_tests.rs
+++ b/src/protocol_invariant_tests.rs
@@ -1,0 +1,54 @@
+#[cfg(test)]
+mod tests {
+    use crate::protocol::{
+        read_f64, read_option_f64, read_option_u32, read_u32, PayloadCursor,
+    };
+
+    #[test]
+    fn read_u32_rejects_offset_overflow_without_panicking() {
+        assert!(read_u32(&[], usize::MAX).is_err());
+    }
+
+    #[test]
+    fn read_f64_rejects_offset_overflow_without_panicking() {
+        assert!(read_f64(&[], usize::MAX).is_err());
+    }
+
+    #[test]
+    fn free_option_u32_uses_same_fixed_width_as_cursor() {
+        assert!(read_option_u32(&[0], 0).is_err());
+
+        let bytes = [0, 0, 0, 0, 0];
+        assert_eq!(read_option_u32(&bytes, 0).unwrap(), None);
+
+        let mut cursor = PayloadCursor::new(&bytes);
+        assert_eq!(cursor.read_option_u32().unwrap(), None);
+        assert_eq!(cursor.remaining(), 0);
+    }
+
+    #[test]
+    fn free_option_f64_uses_same_fixed_width_as_cursor() {
+        assert!(read_option_f64(&[0], 0).is_err());
+
+        let bytes = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(read_option_f64(&bytes, 0).unwrap(), None);
+
+        let mut cursor = PayloadCursor::new(&bytes);
+        assert_eq!(cursor.read_option_f64().unwrap(), None);
+        assert_eq!(cursor.remaining(), 0);
+    }
+
+    #[test]
+    fn free_option_u32_decodes_present_value() {
+        let mut bytes = vec![1];
+        bytes.extend_from_slice(&42u32.to_le_bytes());
+        assert_eq!(read_option_u32(&bytes, 0).unwrap(), Some(42));
+    }
+
+    #[test]
+    fn free_option_f64_decodes_present_value() {
+        let mut bytes = vec![1];
+        bytes.extend_from_slice(&3.5f64.to_le_bytes());
+        assert_eq!(read_option_f64(&bytes, 0).unwrap(), Some(3.5));
+    }
+}


### PR DESCRIPTION
Superseded by #27, which preserves the canonical fixed-width Option semantics, adds checked offset arithmetic, keeps the change isolated to src/protocol.rs, passed CI, and has been merged into main.