### PR TITLE
Harden tensor bridge shape and buffer invariants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ impl TensorView {
     /// Copy data dari SAB ke slice Rust (Rust baca data JS)
     pub fn read(&self, dst: &mut [f32]) {
         if dst.len() != self.len() {
-            bridge_fail(format!(
+            bridge_fail::<()>(format!(
                 "TensorView read length mismatch: view has {}, destination has {}",
                 self.len(),
                 dst.len()
@@ -160,7 +160,7 @@ impl TensorView {
     /// Copy data dari slice Rust ke SAB (Rust tulis data untuk JS)
     pub fn write(&self, src: &[f32]) {
         if src.len() != self.len() {
-            bridge_fail(format!(
+            bridge_fail::<()>(format!(
                 "TensorView write length mismatch: view has {}, source has {}",
                 self.len(),
                 src.len()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,74 @@
-use wasm_bindgen::prelude::*;
 use burn::prelude::*;
 use burn::tensor::TensorData;
 use js_sys::Float32Array;
+use wasm_bindgen::prelude::*;
 
+pub mod es;
+pub mod graph;
 pub mod layers;
 pub mod protocol;
 pub mod registry;
-pub mod es;
-pub mod graph;
+#[cfg(test)]
+mod tensor_invariant_tests;
 #[cfg(test)]
 mod tests;
 
 pub type WasmBackend = burn_ndarray::NdArray<f32>;
+
+pub(crate) fn normalize_4d_shape(
+    shape: &[usize],
+    total_elements: usize,
+) -> Result<[usize; 4], String> {
+    if shape.len() > 4 {
+        return Err(format!(
+            "tensor shape rank must be <= 4, got {}",
+            shape.len()
+        ));
+    }
+
+    let mut dims = [1usize; 4];
+    let mut elements = 1usize;
+    for (i, &dim) in shape.iter().enumerate() {
+        elements = elements
+            .checked_mul(dim)
+            .ok_or_else(|| "tensor shape element count overflow".to_string())?;
+        dims[i] = dim;
+    }
+
+    if elements != total_elements {
+        return Err(format!(
+            "tensor shape/data mismatch: shape has {} elements, buffer has {}",
+            elements, total_elements
+        ));
+    }
+
+    Ok(dims)
+}
+
+pub(crate) fn tensor_view_byte_len(total_elements: usize) -> Result<u32, String> {
+    let bytes = total_elements
+        .checked_mul(core::mem::size_of::<f32>())
+        .ok_or_else(|| "TensorView byte length overflow".to_string())?;
+    u32::try_from(bytes).map_err(|_| {
+        format!(
+            "TensorView byte length {} exceeds SharedArrayBuffer u32 limit",
+            bytes
+        )
+    })
+}
+
+#[inline]
+fn bridge_fail<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
 
 // -------------------------------------------------------------
 // WASM TENSOR — 4D tensor bridge
@@ -19,7 +76,7 @@ pub type WasmBackend = burn_ndarray::NdArray<f32>;
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct WasmTensor {
-    pub(crate) inner: Tensor<WasmBackend, 4>, 
+    pub(crate) inner: Tensor<WasmBackend, 4>,
 }
 
 #[wasm_bindgen]
@@ -27,10 +84,7 @@ impl WasmTensor {
     #[wasm_bindgen(constructor)]
     pub fn new(data: &[f32], shape: &[usize]) -> WasmTensor {
         let device = Default::default();
-        let mut dims = [1usize, 1, 1, 1];
-        for (i, &d) in shape.iter().enumerate().take(4) {
-            dims[i] = d;
-        }
+        let dims = normalize_4d_shape(shape, data.len()).unwrap_or_else(bridge_fail);
         let tensor_data = TensorData::new(data.to_vec(), dims);
         let tensor = Tensor::from_data(tensor_data, &device);
         WasmTensor { inner: tensor }
@@ -46,7 +100,7 @@ impl WasmTensor {
     }
 
     pub fn byte_length(&self) -> usize {
-        self.inner.dims().iter().product::<usize>() * 4 
+        self.inner.dims().iter().product::<usize>() * core::mem::size_of::<f32>()
     }
 }
 
@@ -63,10 +117,11 @@ pub struct TensorView {
 impl TensorView {
     #[wasm_bindgen(constructor)]
     pub fn new(total_elements: usize) -> Self {
-        let sab = js_sys::SharedArrayBuffer::new((total_elements * 4) as u32);
-        TensorView { 
-            sab: JsValue::from(sab), 
-            shape: vec![1, 1, 1, 1] 
+        let byte_len = tensor_view_byte_len(total_elements).unwrap_or_else(bridge_fail);
+        let sab = js_sys::SharedArrayBuffer::new(byte_len);
+        TensorView {
+            sab: JsValue::from(sab),
+            shape: vec![total_elements, 1, 1, 1],
         }
     }
 
@@ -77,6 +132,7 @@ impl TensorView {
 
     #[wasm_bindgen(js_name = setShape)]
     pub fn set_shape(&mut self, shape: Vec<usize>) {
+        normalize_4d_shape(&shape, self.len()).unwrap_or_else(bridge_fail);
         self.shape = shape;
     }
 
@@ -90,12 +146,26 @@ impl TensorView {
 
     /// Copy data dari SAB ke slice Rust (Rust baca data JS)
     pub fn read(&self, dst: &mut [f32]) {
+        if dst.len() != self.len() {
+            bridge_fail(format!(
+                "TensorView read length mismatch: view has {}, destination has {}",
+                self.len(),
+                dst.len()
+            ));
+        }
         let arr = self.as_f32_array();
         arr.copy_to(dst);
     }
 
     /// Copy data dari slice Rust ke SAB (Rust tulis data untuk JS)
     pub fn write(&self, src: &[f32]) {
+        if src.len() != self.len() {
+            bridge_fail(format!(
+                "TensorView write length mismatch: view has {}, source has {}",
+                self.len(),
+                src.len()
+            ));
+        }
         let arr = self.as_f32_array();
         arr.copy_from(src);
     }
@@ -109,16 +179,16 @@ impl WasmTensor {
     #[wasm_bindgen(js_name = fromTensorView)]
     pub fn from_tensor_view(view: &TensorView) -> WasmTensor {
         let device = Default::default();
-        let mut dims = [1usize; 4];
-        for (i, &d) in view.shape().iter().enumerate().take(4) {
-            dims[i] = d;
-        }
+        let shape = view.shape();
+        let dims = normalize_4d_shape(&shape, view.len()).unwrap_or_else(bridge_fail);
 
         let mut buf = vec![0f32; view.len()];
         view.read(&mut buf);
 
         let tensor_data = TensorData::new(buf, dims);
-        WasmTensor { inner: Tensor::from_data(tensor_data, &device) }
+        WasmTensor {
+            inner: Tensor::from_data(tensor_data, &device),
+        }
     }
 
     #[wasm_bindgen(js_name = toTensorView)]
@@ -129,4 +199,3 @@ impl WasmTensor {
         view.set_shape(self.inner.dims().into());
     }
 }
-

--- a/src/tensor_invariant_tests.rs
+++ b/src/tensor_invariant_tests.rs
@@ -1,0 +1,38 @@
+#[cfg(test)]
+mod tests {
+    use crate::{normalize_4d_shape, tensor_view_byte_len};
+
+    #[test]
+    fn shape_is_padded_to_four_dimensions() {
+        assert_eq!(normalize_4d_shape(&[2, 3], 6).unwrap(), [2, 3, 1, 1]);
+    }
+
+    #[test]
+    fn shape_data_mismatch_is_rejected_before_backend() {
+        assert!(normalize_4d_shape(&[2, 3], 5).is_err());
+    }
+
+    #[test]
+    fn rank_above_four_is_rejected_instead_of_truncated() {
+        assert!(normalize_4d_shape(&[1, 1, 1, 1, 1], 1).is_err());
+    }
+
+    #[test]
+    fn shape_element_overflow_is_rejected() {
+        assert!(normalize_4d_shape(&[usize::MAX, 2], 0).is_err());
+    }
+
+    #[test]
+    fn zero_sized_layout_remains_representable() {
+        assert_eq!(normalize_4d_shape(&[0, 4], 0).unwrap(), [0, 4, 1, 1]);
+    }
+
+    #[test]
+    fn tensor_view_byte_length_is_checked() {
+        assert_eq!(tensor_view_byte_len(8).unwrap(), 32);
+        if usize::BITS > 32 {
+            let too_many = (u32::MAX as usize / 4) + 1;
+            assert!(tensor_view_byte_len(too_many).is_err());
+        }
+    }
+}


### PR DESCRIPTION
Superseded by #26, which enforces the tensor memory-shape contract more comprehensively, passed host + WASM CI, and has been merged into main.