### PR TITLE
Harden custom layer configuration boundaries

### DIFF
--- a/src/layers/custom/ghost.rs
+++ b/src/layers/custom/ghost.rs
@@ -1,9 +1,23 @@
-use burn::prelude::*;
 use burn::nn::conv::{Conv2d, Conv2dConfig};
 use burn::nn::PaddingConfig2d;
+use burn::prelude::*;
 use burn::record::{BinBytesRecorder, FullPrecisionSettings, Recorder};
 use wasm_bindgen::prelude::*;
+
 use crate::{WasmBackend, WasmTensor};
+
+#[inline]
+fn reject_invalid_config<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
 
 // --- CONFIGURATION ---
 #[derive(Config, Debug)]
@@ -20,40 +34,57 @@ pub struct GhostModuleConfig {
 }
 
 impl GhostModuleConfig {
-    pub fn init<B: Backend>(&self, device: &B::Device) -> GhostModule<B> {
-        assert!(
-            self.out_channels % self.ratio == 0,
-            "out_channels must be divisible by ratio"
-        );
+    pub fn validate(&self) -> Result<(), String> {
+        if self.in_channels == 0 {
+            return Err("ghost: in_channels must be > 0".into());
+        }
+        if self.out_channels == 0 {
+            return Err("ghost: out_channels must be > 0".into());
+        }
+        if self.kernel_size.iter().any(|&v| v == 0) {
+            return Err("ghost: kernel dimensions must be > 0".into());
+        }
+        if self.stride.iter().any(|&v| v == 0) {
+            return Err("ghost: stride dimensions must be > 0".into());
+        }
+        if self.ratio == 0 {
+            return Err("ghost: ratio must be > 0".into());
+        }
+        if self.out_channels % self.ratio != 0 {
+            return Err(format!(
+                "ghost: out_channels ({}) must be divisible by ratio ({})",
+                self.out_channels, self.ratio
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn try_init<B: Backend>(&self, device: &B::Device) -> Result<GhostModule<B>, String> {
+        self.validate()?;
 
         let primary_ch = self.out_channels / self.ratio;
 
-        // Primary conv: full Conv2d biasa
-        // Conv2dConfig::new(channels, kernel_size) — channels = [in, out]
-        let mut primary_cfg = Conv2dConfig::new(
-            [self.in_channels, primary_ch],
-            self.kernel_size,
-        );
+        let mut primary_cfg =
+            Conv2dConfig::new([self.in_channels, primary_ch], self.kernel_size);
         primary_cfg.stride = self.stride;
         primary_cfg.padding = PaddingConfig2d::Explicit(self.padding[0], self.padding[1]);
         let primary = primary_cfg.init(device);
 
-        // Cheap conv: depthwise (groups = primary_ch) pada output primary
-        // Kernel 1x1 untuk efisiensi maksimal, no bias
-        let mut cheap_cfg = Conv2dConfig::new(
-            [primary_ch, primary_ch],
-            [1, 1],
-        );
+        let mut cheap_cfg = Conv2dConfig::new([primary_ch, primary_ch], [1, 1]);
         cheap_cfg.groups = primary_ch;
         cheap_cfg.bias = false;
         let cheap = cheap_cfg.init(device);
 
-        GhostModule {
+        Ok(GhostModule {
             primary,
             cheap,
             ratio: self.ratio,
             primary_ch,
-        }
+        })
+    }
+
+    pub fn init<B: Backend>(&self, device: &B::Device) -> GhostModule<B> {
+        self.try_init(device).unwrap_or_else(|e| panic!("{e}"))
     }
 }
 
@@ -68,13 +99,8 @@ pub struct GhostModule<B: Backend> {
 
 impl<B: Backend> GhostModule<B> {
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
-        // 1. Primary conv → intrinsic feature maps
         let intrinsic = self.primary.forward(input);
-
-        // 2. Cheap depthwise conv pada intrinsic → ghost feature maps
         let ghost = self.cheap.forward(intrinsic.clone());
-
-        // 3. Concat intrinsic + ghost
         Tensor::cat(vec![intrinsic, ghost], 1)
     }
 }
@@ -100,7 +126,8 @@ impl WasmGhostModule {
         padding_w: Option<usize>,
     ) -> WasmGhostModule {
         let device = Default::default();
-        let mut config = GhostModuleConfig::new(in_channels, out_channels, [kernel_size_h, kernel_size_w]);
+        let mut config =
+            GhostModuleConfig::new(in_channels, out_channels, [kernel_size_h, kernel_size_w]);
         if let Some(r) = ratio {
             config.ratio = r;
         }
@@ -110,9 +137,8 @@ impl WasmGhostModule {
         if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
             config.padding = [ph, pw];
         }
-        WasmGhostModule {
-            inner: config.init(&device),
-        }
+        let inner = config.try_init(&device).unwrap_or_else(reject_invalid_config);
+        WasmGhostModule { inner }
     }
 
     pub fn forward(&self, input: &WasmTensor) -> WasmTensor {
@@ -140,5 +166,39 @@ impl WasmGhostModule {
             .record(record, ())
             .map_err(|e| e.to_string())?;
         Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GhostModuleConfig;
+
+    #[test]
+    fn validation_rejects_zero_ratio_before_modulo() {
+        let mut cfg = GhostModuleConfig::new(4, 8, [3, 3]);
+        cfg.ratio = 0;
+        assert!(cfg.validate().unwrap_err().contains("ratio must be > 0"));
+    }
+
+    #[test]
+    fn validation_rejects_non_divisible_channels() {
+        let mut cfg = GhostModuleConfig::new(4, 7, [3, 3]);
+        cfg.ratio = 2;
+        assert!(cfg.validate().unwrap_err().contains("must be divisible"));
+    }
+
+    #[test]
+    fn validation_rejects_zero_kernel_or_stride() {
+        let mut cfg = GhostModuleConfig::new(4, 8, [0, 3]);
+        assert!(cfg.validate().is_err());
+        cfg.kernel_size = [3, 3];
+        cfg.stride = [1, 0];
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validation_accepts_existing_valid_contract() {
+        let cfg = GhostModuleConfig::new(4, 8, [3, 3]);
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/src/layers/custom/seblock.rs
+++ b/src/layers/custom/seblock.rs
@@ -1,9 +1,23 @@
-use burn::prelude::*;
-use burn::nn::{Linear, LinearConfig, Relu, Sigmoid};
 use burn::nn::pool::{AdaptiveAvgPool2d, AdaptiveAvgPool2dConfig};
+use burn::nn::{Linear, LinearConfig, Relu, Sigmoid};
+use burn::prelude::*;
 use burn::record::{BinBytesRecorder, FullPrecisionSettings, Recorder};
 use wasm_bindgen::prelude::*;
+
 use crate::{WasmBackend, WasmTensor};
+
+#[inline]
+fn reject_invalid_config<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
 
 // --- CONFIGURATION ---
 #[derive(Config, Debug)]
@@ -14,29 +28,44 @@ pub struct SeBlockConfig {
 }
 
 impl SeBlockConfig {
-    pub fn init<B: Backend>(&self, device: &B::Device) -> SeBlock<B> {
-        assert!(self.channels >= self.reduction, "channels must be >= reduction");
+    pub fn validate(&self) -> Result<(), String> {
+        if self.channels == 0 {
+            return Err("seblock: channels must be > 0".into());
+        }
+        if self.reduction == 0 {
+            return Err("seblock: reduction must be > 0".into());
+        }
+        if self.channels < self.reduction {
+            return Err(format!(
+                "seblock: channels ({}) must be >= reduction ({})",
+                self.channels, self.reduction
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn try_init<B: Backend>(&self, device: &B::Device) -> Result<SeBlock<B>, String> {
+        self.validate()?;
         let reduced = self.channels / self.reduction;
 
-        // Squeeze: Global Average Pooling (AdaptiveAvgPool2d to [1,1])
         let squeeze = AdaptiveAvgPool2dConfig::new([1, 1]).init();
-
-        // Excitation: FC1 (channels → channels/reduction) + ReLU
         let fc1 = LinearConfig::new(self.channels, reduced).init(device);
         let relu = Relu::new();
-
-        // Excitation: FC2 (channels/reduction → channels) + Sigmoid
         let fc2 = LinearConfig::new(reduced, self.channels).init(device);
         let sigmoid = Sigmoid::new();
 
-        SeBlock {
+        Ok(SeBlock {
             squeeze,
             fc1,
             relu,
             fc2,
             sigmoid,
             channels: self.channels,
-        }
+        })
+    }
+
+    pub fn init<B: Backend>(&self, device: &B::Device) -> SeBlock<B> {
+        self.try_init(device).unwrap_or_else(|e| panic!("{e}"))
     }
 }
 
@@ -54,25 +83,13 @@ pub struct SeBlock<B: Backend> {
 impl<B: Backend> SeBlock<B> {
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let [b, c, _h, _w] = input.dims();
-
-        // Squeeze: Global Average Pooling → [B, C, 1, 1]
         let pooled = self.squeeze.forward(input.clone());
-
-        // Flatten → [B, C]
         let flat = pooled.reshape([b, c]);
-
-        // Excitation: FC1 + ReLU → [B, C/r]
         let x = self.fc1.forward(flat);
         let x = self.relu.forward(x);
-
-        // Excitation: FC2 + Sigmoid → [B, C]
         let x = self.fc2.forward(x);
         let weights = self.sigmoid.forward(x);
-
-        // Reshape weights → [B, C, 1, 1] untuk broadcast multiply
         let weights_4d = weights.reshape([b, c, 1, 1]);
-
-        // Scale: input * weights (broadcast)
         input * weights_4d
     }
 }
@@ -92,9 +109,8 @@ impl WasmSeBlock {
         if let Some(r) = reduction {
             config.reduction = r;
         }
-        WasmSeBlock {
-            inner: config.init(&device),
-        }
+        let inner = config.try_init(&device).unwrap_or_else(reject_invalid_config);
+        WasmSeBlock { inner }
     }
 
     pub fn forward(&self, input: &WasmTensor) -> WasmTensor {
@@ -122,5 +138,39 @@ impl WasmSeBlock {
             .record(record, ())
             .map_err(|e| e.to_string())?;
         Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SeBlockConfig;
+
+    #[test]
+    fn validation_rejects_zero_reduction_before_division() {
+        let mut cfg = SeBlockConfig::new(16);
+        cfg.reduction = 0;
+        assert!(cfg
+            .validate()
+            .unwrap_err()
+            .contains("reduction must be > 0"));
+    }
+
+    #[test]
+    fn validation_rejects_reduction_larger_than_channels() {
+        let mut cfg = SeBlockConfig::new(8);
+        cfg.reduction = 16;
+        assert!(cfg.validate().unwrap_err().contains("must be >= reduction"));
+    }
+
+    #[test]
+    fn validation_rejects_zero_channels() {
+        let cfg = SeBlockConfig::new(0);
+        assert!(cfg.validate().unwrap_err().contains("channels must be > 0"));
+    }
+
+    #[test]
+    fn validation_accepts_existing_valid_contract() {
+        let cfg = SeBlockConfig::new(16);
+        assert!(cfg.validate().is_ok());
     }
 }


### PR DESCRIPTION
## Tujuan
Memperkuat konfigurasi GhostModule dan SEBlock yang sudah ada tanpa mengubah API valid dan tanpa bergantung pada PR lain.

## Perubahan
- tambah `validate()` dan `try_init()` pada `GhostModuleConfig`
- tolak `ratio=0`, channel nol, kernel nol, stride nol, dan out_channels yang tidak divisible sebelum modulo/backend
- tambah `validate()` dan `try_init()` pada `SeBlockConfig`
- tolak `reduction=0`, channels nol, dan reduction > channels sebelum division/backend
- constructor WASM mempertahankan signature lama; invalid config menjadi JS exception terkontrol, bukan arithmetic/assert trap
- tambah 8 unit test pada dua custom layer

## Invariant yang dipertahankan
- constructor valid tidak berubah
- konfigurasi default tetap sama
- forward/state serialization tidak berubah
- tidak ada perubahan pada registry, graph, protocol, tensor bridge, atau ES

## Independensi
Branch dibuat langsung dari `main` dan tidak membawa PR #1–#17.