### PR TITLE
Harden core layer forward shape contracts

### DIFF
--- a/src/layers/conv.rs
+++ b/src/layers/conv.rs
@@ -7,6 +7,7 @@ use burn::nn::conv::{
 use burn::record::{BinBytesRecorder, FullPrecisionSettings, Recorder};
 use wasm_bindgen::prelude::*;
 use crate::{WasmBackend, WasmTensor};
+use crate::layers::shape_contract::require_singleton_axis;
 
 // --- CONFIGURATION ENUM ---
 #[derive(Config, Debug)]
@@ -128,9 +129,8 @@ impl WasmConv {
     }
 
     pub fn forward(&self, input: &WasmTensor) -> WasmTensor {
-        let x = input.inner.clone();
-        let out = self.inner.forward(x);
-        WasmTensor { inner: out }
+        self.try_forward(input)
+            .unwrap_or_else(crate::layers::shape_contract::forward_fail)
     }
 
     pub fn num_params(&self) -> usize {
@@ -152,6 +152,16 @@ impl WasmConv {
             .record(record, ())
             .map_err(|e| e.to_string())?;
         Ok(bytes)
+    }
+}
+
+impl WasmConv {
+    pub(crate) fn try_forward(&self, input: &WasmTensor) -> Result<WasmTensor, String> {
+        if matches!(&self.inner, Convolution::Conv1d(_)) {
+            require_singleton_axis(input.inner.dims(), 3, "Conv1d forward")?;
+        }
+        let out = self.inner.forward(input.inner.clone());
+        Ok(WasmTensor { inner: out })
     }
 }
 
@@ -213,7 +223,7 @@ impl WasmConv {
         let rec = self.inner.clone().into_record();
         let mut out = Vec::new();
         match rec {
-            ConvolutionRecord::Conv1d(r) => { // TITIK API: nama record
+            ConvolutionRecord::Conv1d(r) => {
                 push_param::<WasmBackend, 3>(&r.weight, &mut out)?;
                 if let Some(b) = &r.bias { push_param::<WasmBackend, 1>(b, &mut out)?; }
             }
@@ -267,7 +277,7 @@ impl WasmConv {
         let rec = self.inner.clone().into_record();
         let mut segs = Vec::new();
         match rec {
-            ConvolutionRecord::Conv1d(r) => { // TITIK API (terbukti di M1)
+            ConvolutionRecord::Conv1d(r) => {
                 push_conv_segs::<WasmBackend, 3>(&r.weight, &r.bias, &mut segs);
             }
             ConvolutionRecord::Conv2d(r) => {

--- a/src/layers/embedding.rs
+++ b/src/layers/embedding.rs
@@ -3,6 +3,7 @@ use burn::nn::{Embedding, EmbeddingConfig};
 use burn::record::{BinBytesRecorder, FullPrecisionSettings, Recorder};
 use wasm_bindgen::prelude::*;
 use crate::{WasmBackend, WasmTensor};
+use crate::layers::shape_contract::require_singleton_spatial;
 
 // --- CONFIGURATION ENUM ---
 #[derive(Config, Debug)]
@@ -69,9 +70,8 @@ impl WasmEmbedding {
     }
 
     pub fn forward(&self, input: &WasmTensor) -> WasmTensor {
-        let x = input.inner.clone();
-        let out = self.inner.forward(x);
-        WasmTensor { inner: out }
+        self.try_forward(input)
+            .unwrap_or_else(crate::layers::shape_contract::forward_fail)
     }
 
     pub fn num_params(&self) -> usize {
@@ -96,6 +96,14 @@ impl WasmEmbedding {
     }
 }
 
+impl WasmEmbedding {
+    pub(crate) fn try_forward(&self, input: &WasmTensor) -> Result<WasmTensor, String> {
+        require_singleton_spatial(input.inner.dims(), "Embedding forward")?;
+        let out = self.inner.forward(input.inner.clone());
+        Ok(WasmTensor { inner: out })
+    }
+}
+
 // ============================================================
 // FLOAT-BRIDGE (M1) — embedding. Record = { weight: Param<T2> } (tanpa bias).
 // ============================================================
@@ -105,7 +113,7 @@ impl WasmEmbedding {
     pub fn weight_dims(&self) -> Vec<usize> {
         let rec = self.inner.clone().into_record();
         match rec {
-            EmbeddingLayerRecord::Basic(r) => r.weight.dims().to_vec(), // TITIK API: nama record + field
+            EmbeddingLayerRecord::Basic(r) => r.weight.dims().to_vec(),
         }
     }
 
@@ -151,7 +159,7 @@ impl WasmEmbedding {
     pub fn weight_segs(&self) -> Vec<(&'static str, usize)> {
         let rec = self.inner.clone().into_record();
         match rec {
-            EmbeddingLayerRecord::Basic(r) => { // TITIK API (terbukti di M1)
+            EmbeddingLayerRecord::Basic(r) => {
                 vec![("weight", r.weight.dims().iter().product::<usize>())]
             }
         }

--- a/src/layers/linear.rs
+++ b/src/layers/linear.rs
@@ -3,6 +3,7 @@ use burn::nn::{Linear, LinearConfig};
 use burn::record::{BinBytesRecorder, FullPrecisionSettings, Recorder};
 use wasm_bindgen::prelude::*;
 use crate::{WasmBackend, WasmTensor};
+use crate::layers::shape_contract::{require_axis_size, require_singleton_spatial};
 
 // --- CONFIG & MODULE ---
 #[derive(Config, Debug)]
@@ -53,13 +54,8 @@ impl WasmLinear {
     }
 
     pub fn forward(&self, input: &WasmTensor) -> WasmTensor {
-        let x = input.inner.clone();
-        let [b, d, _, _] = x.dims(); 
-        let x_2d = x.reshape([b, d]); 
-        let out = self.inner.forward(x_2d);
-        let [b_out, d_out] = out.dims();
-        let out_4d = out.reshape([b_out, d_out, 1, 1]);
-        WasmTensor { inner: out_4d }
+        self.try_forward(input)
+            .unwrap_or_else(crate::layers::shape_contract::forward_fail)
     }
 
     pub fn num_params(&self) -> usize {
@@ -84,7 +80,25 @@ impl WasmLinear {
             .map_err(|e| e.to_string())?;
         Ok(bytes)
     }
-            }
+}
+
+impl WasmLinear {
+    pub(crate) fn try_forward(&self, input: &WasmTensor) -> Result<WasmTensor, String> {
+        let x = input.inner.clone();
+        let shape = x.dims();
+        require_singleton_spatial(shape, "Linear forward")?;
+        let expected_features = self.weight_dims()[0];
+        require_axis_size(shape, 1, expected_features, "Linear forward")?;
+
+        let [b, d, _, _] = shape;
+        let x_2d = x.reshape([b, d]);
+        let out = self.inner.forward(x_2d);
+        let [b_out, d_out] = out.dims();
+        let out_4d = out.reshape([b_out, d_out, 1, 1]);
+        Ok(WasmTensor { inner: out_4d })
+    }
+}
+
 // ============================================================
 // FLOAT-BRIDGE (B) — baca/tulis bobot sebagai Vec<f32> flat.
 // Ini kabel yang membuat ES (gradient-free) bisa menyentuh bobot,
@@ -98,21 +112,19 @@ impl WasmLinear {
     /// [in_dim, out_dim] — supaya JS tahu cara memotong vektor flat.
     #[wasm_bindgen(js_name = weightDims)]
     pub fn weight_dims(&self) -> Vec<usize> {
-        let rec = self.inner.inner.clone().into_record();          // TITIK API #1
-        rec.weight.dims().to_vec()                                 // TITIK API #3 (field `weight`)
+        let rec = self.inner.inner.clone().into_record();
+        rec.weight.dims().to_vec()
     }
 
-#[wasm_bindgen(js_name = getWeightsFlat)]
+    #[wasm_bindgen(js_name = getWeightsFlat)]
     pub fn get_weights_flat(&self) -> Result<Vec<f32>, String> {
         let rec = self.inner.inner.clone().into_record();
-        // rec.weight: Param<Tensor<_,2>> -> clone via deref jadi Tensor owned, baru into_data.
         let w = <Tensor<WasmBackend, 2> as Clone>::clone(&rec.weight).into_data();
         let mut out = w
             .as_slice::<f32>()
             .map_err(|_| "getWeightsFlat: weight not f32".to_string())?
             .to_vec();
         if let Some(b) = &rec.bias {
-            // b: &Param<Tensor<_,1>> -> clone via deref.
             let bv = <Tensor<WasmBackend, 1> as Clone>::clone(b)
                 .into_data()
                 .as_slice::<f32>()
@@ -122,7 +134,8 @@ impl WasmLinear {
         }
         Ok(out)
     }
-#[wasm_bindgen(js_name = setWeightsFlat)]
+
+    #[wasm_bindgen(js_name = setWeightsFlat)]
     pub fn set_weights_flat(&mut self, data: &[f32]) -> Result<(), String> {
         let mut rec = self.inner.inner.clone().into_record();
         let wd = rec.weight.dims(); // [in, out]
@@ -139,7 +152,6 @@ impl WasmLinear {
             ));
         }
         let device: <WasmBackend as Backend>::Device = Default::default();
-        // rec.weight: Param<Tensor<_,2>> -> pakai constructor resmi 0.20 (bukan .into()).
         rec.weight = burn::module::Param::from_data(
             burn::tensor::TensorData::new(data[..in_d * out_d].to_vec(), [in_d, out_d]),
             &device,

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -7,3 +7,4 @@ pub mod pool;
 pub mod binary;
 pub mod custom;
 pub mod layout;
+pub(crate) mod shape_contract;

--- a/src/layers/pool.rs
+++ b/src/layers/pool.rs
@@ -9,6 +9,7 @@ use burn::nn::pool::{
 use burn::nn::{PaddingConfig1d, PaddingConfig2d};
 use wasm_bindgen::prelude::*;
 use crate::WasmTensor;
+use crate::layers::shape_contract::require_singleton_axis;
 
 // --- CONFIGURATION ENUM ---
 #[derive(Debug)]
@@ -172,13 +173,22 @@ impl WasmPool {
     }
 
     pub fn forward(&self, input: &WasmTensor) -> WasmTensor {
-        let x = input.inner.clone();
-        let out = self.inner.forward(x);
-        WasmTensor { inner: out }
+        self.try_forward(input)
+            .unwrap_or_else(crate::layers::shape_contract::forward_fail)
     }
 
     // Pooling tidak punya trainable params
     pub fn num_params(&self) -> usize {
         0
+    }
+}
+
+impl WasmPool {
+    pub(crate) fn try_forward(&self, input: &WasmTensor) -> Result<WasmTensor, String> {
+        if matches!(&self.inner, Pooling::MaxPool1d(_) | Pooling::AvgPool1d(_)) {
+            require_singleton_axis(input.inner.dims(), 3, "Pool1d forward")?;
+        }
+        let out = self.inner.forward(input.inner.clone());
+        Ok(WasmTensor { inner: out })
     }
 }

--- a/src/layers/shape_contract.rs
+++ b/src/layers/shape_contract.rs
@@ -1,0 +1,87 @@
+pub(crate) fn require_singleton_axis(
+    shape: [usize; 4],
+    axis: usize,
+    context: &str,
+) -> Result<(), String> {
+    if axis >= shape.len() {
+        return Err(format!("{context}: invalid shape axis {axis}"));
+    }
+    if shape[axis] != 1 {
+        return Err(format!(
+            "{context}: expected axis {axis} to be 1, got {} for shape {:?}",
+            shape[axis], shape
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn require_singleton_spatial(
+    shape: [usize; 4],
+    context: &str,
+) -> Result<(), String> {
+    require_singleton_axis(shape, 2, context)?;
+    require_singleton_axis(shape, 3, context)
+}
+
+pub(crate) fn require_axis_size(
+    shape: [usize; 4],
+    axis: usize,
+    expected: usize,
+    context: &str,
+) -> Result<(), String> {
+    if axis >= shape.len() {
+        return Err(format!("{context}: invalid shape axis {axis}"));
+    }
+    if shape[axis] != expected {
+        return Err(format!(
+            "{context}: expected axis {axis} size {expected}, got {} for shape {:?}",
+            shape[axis], shape
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn forward_fail<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn singleton_spatial_accepts_canonical_linear_shape() {
+        assert!(require_singleton_spatial([2, 8, 1, 1], "linear").is_ok());
+    }
+
+    #[test]
+    fn singleton_spatial_rejects_hidden_height_elements() {
+        let err = require_singleton_spatial([2, 8, 3, 1], "linear").unwrap_err();
+        assert!(err.contains("axis 2"));
+    }
+
+    #[test]
+    fn singleton_width_rejects_hidden_width_elements() {
+        let err = require_singleton_axis([2, 4, 6, 3], 3, "conv1d").unwrap_err();
+        assert!(err.contains("axis 3"));
+    }
+
+    #[test]
+    fn axis_size_rejects_linear_feature_mismatch() {
+        let err = require_axis_size([4, 7, 1, 1], 1, 8, "linear").unwrap_err();
+        assert!(err.contains("size 8"));
+    }
+
+    #[test]
+    fn axis_size_accepts_expected_dimension() {
+        assert!(require_axis_size([4, 8, 1, 1], 1, 8, "linear").is_ok());
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -39,6 +39,7 @@ macro_rules! insert_layer {
         $self.cached_params = $self.cached_params.saturating_add(new_params);
     }};
 }
+
 macro_rules! remove_layer {
     ($self:ident, $map:ident, $id:expr) => {{
         if let Some(old) = $self.$map.remove(&$id) {
@@ -49,6 +50,7 @@ macro_rules! remove_layer {
         }
     }};
 }
+
 macro_rules! load_layer_state {
     ($self:ident, $map:ident, $id:expr, $data:expr) => {{
         match $self.$map.get_mut(&$id) {
@@ -110,17 +112,58 @@ impl LayerRegistry {
     }
 
     #[wasm_bindgen(js_name = forwardLayer)]
-    pub fn forward_layer(&self, layer_id: LayerId, layer_type: u8, input: &WasmTensor) -> Result<WasmTensor, String> {
+    pub fn forward_layer(
+        &self,
+        layer_id: LayerId,
+        layer_type: u8,
+        input: &WasmTensor,
+    ) -> Result<WasmTensor, String> {
         match layer_type {
-            LAYER_LINEAR      => self.linears.get(&layer_id).map(|l| l.forward(input)).ok_or("Linear not found".into()),
-            LAYER_NORM        => self.norms.get(&layer_id).map(|l| l.forward(input)).ok_or("Norm not found".into()),
-            LAYER_CONV        => self.convs.get(&layer_id).map(|l| l.forward(input)).ok_or("Conv not found".into()),
-            LAYER_ACTIVATION  => self.activations.get(&layer_id).map(|l| l.forward(input)).ok_or("Activation not found".into()),
-            LAYER_EMBEDDING   => self.embeddings.get(&layer_id).map(|l| l.forward(input)).ok_or("Embedding not found".into()),
-            LAYER_POOL        => self.pools.get(&layer_id).map(|l| l.forward(input)).ok_or("Pool not found".into()),
-            LAYER_SHIFT       => self.shifts.get(&layer_id).map(|l| l.forward(input)).ok_or("Shift not found".into()),
-            LAYER_GHOST       => self.ghosts.get(&layer_id).map(|l| l.forward(input)).ok_or("Ghost not found".into()),
-            LAYER_SEBLOCK     => self.seblocks.get(&layer_id).map(|l| l.forward(input)).ok_or("SEBlock not found".into()),
+            LAYER_LINEAR => self
+                .linears
+                .get(&layer_id)
+                .ok_or_else(|| "Linear not found".to_string())?
+                .try_forward(input),
+            LAYER_NORM => Ok(self
+                .norms
+                .get(&layer_id)
+                .ok_or_else(|| "Norm not found".to_string())?
+                .forward(input)),
+            LAYER_CONV => self
+                .convs
+                .get(&layer_id)
+                .ok_or_else(|| "Conv not found".to_string())?
+                .try_forward(input),
+            LAYER_ACTIVATION => Ok(self
+                .activations
+                .get(&layer_id)
+                .ok_or_else(|| "Activation not found".to_string())?
+                .forward(input)),
+            LAYER_EMBEDDING => self
+                .embeddings
+                .get(&layer_id)
+                .ok_or_else(|| "Embedding not found".to_string())?
+                .try_forward(input),
+            LAYER_POOL => self
+                .pools
+                .get(&layer_id)
+                .ok_or_else(|| "Pool not found".to_string())?
+                .try_forward(input),
+            LAYER_SHIFT => Ok(self
+                .shifts
+                .get(&layer_id)
+                .ok_or_else(|| "Shift not found".to_string())?
+                .forward(input)),
+            LAYER_GHOST => Ok(self
+                .ghosts
+                .get(&layer_id)
+                .ok_or_else(|| "Ghost not found".to_string())?
+                .forward(input)),
+            LAYER_SEBLOCK => Ok(self
+                .seblocks
+                .get(&layer_id)
+                .ok_or_else(|| "SEBlock not found".to_string())?
+                .forward(input)),
             _ => Err(format!("Unknown layer type for forward: 0x{:02X}", layer_type)),
         }
     }
@@ -135,7 +178,7 @@ impl LayerRegistry {
             LAYER_EMBEDDING   => self.embeddings.get(&layer_id).ok_or("Not found")?.get_state(),
             LAYER_GHOST       => self.ghosts.get(&layer_id).ok_or("Not found")?.get_state(),
             LAYER_SEBLOCK     => self.seblocks.get(&layer_id).ok_or("Not found")?.get_state(),
-            LAYER_POOL | LAYER_SHIFT | LAYER_BINARY => Ok(vec![]), // stateless
+            LAYER_POOL | LAYER_SHIFT | LAYER_BINARY => Ok(vec![]),
             _ => Err(format!("Unknown layer type for get_state: 0x{:02X}", layer_type)),
         }
     }
@@ -150,7 +193,7 @@ impl LayerRegistry {
             LAYER_EMBEDDING   => load_layer_state!(self, embeddings, layer_id, data),
             LAYER_GHOST       => load_layer_state!(self, ghosts, layer_id, data),
             LAYER_SEBLOCK     => load_layer_state!(self, seblocks, layer_id, data),
-            LAYER_POOL | LAYER_SHIFT | LAYER_BINARY => Ok(()), // stateless
+            LAYER_POOL | LAYER_SHIFT | LAYER_BINARY => Ok(()),
             _ => Err(format!("Unknown layer type for load_state: 0x{:02X}", layer_type)),
         }
     }
@@ -177,7 +220,6 @@ impl LayerRegistry {
         self.cached_params
     }
 
-    // ---- init per tipe ----
     fn init_linear(&mut self, _header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
@@ -188,6 +230,7 @@ impl LayerRegistry {
         insert_layer!(self, linears, id, layer);
         Ok(())
     }
+
     fn init_norm(&mut self, header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
@@ -208,6 +251,7 @@ impl LayerRegistry {
         insert_layer!(self, norms, id, layer);
         Ok(())
     }
+
     fn init_conv(&mut self, header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
@@ -228,6 +272,7 @@ impl LayerRegistry {
         insert_layer!(self, convs, id, layer);
         Ok(())
     }
+
     fn init_activation(&mut self, header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
@@ -279,6 +324,7 @@ impl LayerRegistry {
         insert_layer!(self, activations, id, layer);
         Ok(())
     }
+
     fn init_embedding(&mut self, _header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
@@ -288,6 +334,7 @@ impl LayerRegistry {
         insert_layer!(self, embeddings, id, layer);
         Ok(())
     }
+
     fn init_pool(&mut self, header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
@@ -332,6 +379,7 @@ impl LayerRegistry {
         self.pools.insert(id, layer);
         Ok(())
     }
+
     fn init_shift(&mut self, header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
@@ -346,6 +394,7 @@ impl LayerRegistry {
         self.shifts.insert(id, layer);
         Ok(())
     }
+
     fn init_ghost(&mut self, _header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
@@ -362,6 +411,7 @@ impl LayerRegistry {
         insert_layer!(self, ghosts, id, layer);
         Ok(())
     }
+
     fn init_seblock(&mut self, _header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
@@ -375,7 +425,6 @@ impl LayerRegistry {
 
 // ============================================================
 // IMPL #2 — FLOAT-BRIDGE + WEIGHT LAYOUT (LINEAR/CONV/EMBEDDING/NORM)
-// Satu-satunya tempat ketiga method ini didefinisikan (TIDAK ada duplikat).
 // ============================================================
 #[wasm_bindgen]
 impl LayerRegistry {
@@ -439,7 +488,7 @@ impl LayerRegistry {
     fn init_binary(&mut self, header: &PacketHeader, payload: &[u8]) -> Result<(), String> {
         let mut c = PayloadCursor::new(payload);
         let id = c.read_u32()?;
-        let dim = c.read_usize()?; // hanya bermakna untuk CONCAT
+        let dim = c.read_usize()?;
         let layer = match header.variant {
             BINARY_ADD    => WasmBinary::new_add(),
             BINARY_SUB    => WasmBinary::new_sub(),
@@ -448,7 +497,7 @@ impl LayerRegistry {
             BINARY_CONCAT => WasmBinary::new_concat(dim),
             _ => return Err(format!("Unknown binary variant: 0x{:02X}", header.variant)),
         };
-        self.binaries.insert(id, layer); // stateless: tanpa macro cache
+        self.binaries.insert(id, layer);
         Ok(())
     }
 }
@@ -460,11 +509,11 @@ const MAX_SLOTS: u32 = 64;
 
 #[derive(Clone, Copy)]
 struct RunStep {
-    arity: u8,        // 1 = unary, 2 = binary
+    arity: u8,
     layer_type: u8,
     layer_id: u32,
     in_slot: u8,
-    in_slot2: u8,     // hanya untuk arity 2
+    in_slot2: u8,
     out_slot: u8,
 }
 
@@ -505,7 +554,7 @@ fn validate_plan(reg: &LayerRegistry, plan: &[u8]) -> Result<(u32, u32, u8), Str
     if !(1..=MAX_SLOTS).contains(&num_slots) {
         return Err(format!("run_graph: num_slots must be 1..={}, got {}", MAX_SLOTS, num_slots));
     }
-    let mut filled: u64 = 1; // bit 0 = slot 0 (input eksternal)
+    let mut filled: u64 = 1;
     for _ in 0..num_steps {
         let s = read_run_step(&mut c)?;
         let in_slot = s.in_slot as u32;
@@ -609,4 +658,4 @@ impl LayerRegistry {
     pub fn compile_graph(&self, plan: &[u8]) -> Result<crate::graph::CompiledGraph, String> {
         crate::graph::CompiledGraph::build(self, plan)
     }
-            }
+}


### PR DESCRIPTION
## Tujuan
Mengubah shape mismatch yang sebelumnya jatuh ke backend reshape/matmul panic menjadi boundary error yang terkontrol, tanpa mengubah perilaku input valid dan tanpa bergantung pada PR lain.

## Masalah yang ditutup
- Linear sebelumnya reshape `[b,d,h,w] -> [b,d]` tanpa memastikan `h=w=1`
- Linear feature dimension mismatch baru gagal di backend matmul
- Embedding sebelumnya reshape `[b,s,h,w] -> [b,s]` tanpa memastikan `h=w=1`
- Conv1d dan Pool1d sebelumnya reshape 4D -> 3D sambil mengabaikan width, sehingga `width != 1` dapat panic karena element count berubah

## Perubahan
- tambah validator shape bersama untuk singleton axis/spatial dan expected axis size
- tambah internal `try_forward()` pada Linear, Embedding, Conv, dan Pool
- direct WASM `forward()` mempertahankan signature lama; invalid input menjadi exception terkontrol sebelum backend
- `LayerRegistry.forwardLayer()` memakai `try_forward()` sehingga invalid shape menjadi `Err`
- `runGraph()` otomatis mendapat boundary yang sama melalui `forwardLayer()`
- tambah 5 unit test untuk validator shape

## Invariant yang dipertahankan
- valid Linear `[B,D,1,1]` tetap identik
- valid Embedding `[B,S,1,1]` tetap identik
- valid Conv1d/Pool1d `[B,C,L,1]` tetap identik
- Conv2d/ConvTranspose2d/Pool2d tidak mendapat restriction width baru
- weight/state/layout/lifecycle tidak berubah

## Independensi
Branch dibuat langsung dari `main` pada `8cd0b31`; tidak membawa PR #14–#20.