### PR TITLE
Harden pooling kernel and stride contracts

### DIFF
--- a/src/layers/pool.rs
+++ b/src/layers/pool.rs
@@ -10,6 +10,52 @@ use burn::nn::{PaddingConfig1d, PaddingConfig2d};
 use wasm_bindgen::prelude::*;
 use crate::WasmTensor;
 
+fn validate_pool1d_params(kernel_size: usize, stride: Option<usize>, context: &str) -> Result<(), String> {
+    if kernel_size == 0 {
+        return Err(format!("{context}: kernel_size must be greater than 0"));
+    }
+    if stride == Some(0) {
+        return Err(format!("{context}: stride must be greater than 0"));
+    }
+    Ok(())
+}
+
+fn validate_pool2d_params(
+    kernel_size_h: usize,
+    kernel_size_w: usize,
+    stride_h: Option<usize>,
+    stride_w: Option<usize>,
+    context: &str,
+) -> Result<(), String> {
+    if kernel_size_h == 0 || kernel_size_w == 0 {
+        return Err(format!(
+            "{context}: kernel sizes must be greater than 0, got [{kernel_size_h}, {kernel_size_w}]"
+        ));
+    }
+
+    // Preserve the existing wrapper contract: custom strides are applied only when both are Some.
+    if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
+        if sh == 0 || sw == 0 {
+            return Err(format!(
+                "{context}: strides must be greater than 0, got [{sh}, {sw}]"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn pool_fail<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
+
 // --- CONFIGURATION ENUM ---
 #[derive(Debug)]
 pub enum PoolingConfig {
@@ -87,16 +133,7 @@ impl WasmPool {
         stride: Option<usize>,
         padding: Option<usize>,
     ) -> WasmPool {
-        let mut config = MaxPool1dConfig::new(kernel_size);
-        if let Some(s) = stride {
-            config = config.with_stride(s);
-        }
-        if let Some(p) = padding {
-            config = config.with_padding(PaddingConfig1d::Explicit(p));
-        }
-        WasmPool {
-            inner: PoolingConfig::MaxPool1d(config).init(),
-        }
+        Self::try_new_max_pool1d(kernel_size, stride, padding).unwrap_or_else(pool_fail)
     }
 
     // [usize; 2] dipecah jadi 2 parameter karena wasm_bindgen tidak support array
@@ -109,16 +146,15 @@ impl WasmPool {
         padding_h: Option<usize>,
         padding_w: Option<usize>,
     ) -> WasmPool {
-        let mut config = MaxPool2dConfig::new([kernel_size_h, kernel_size_w]);
-        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
-            config = config.with_strides([sh, sw]);
-        }
-        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
-            config = config.with_padding(PaddingConfig2d::Explicit(ph, pw));
-        }
-        WasmPool {
-            inner: PoolingConfig::MaxPool2d(config).init(),
-        }
+        Self::try_new_max_pool2d(
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+        )
+        .unwrap_or_else(pool_fail)
     }
 
     #[wasm_bindgen(js_name = newAvgPool1d)]
@@ -127,16 +163,7 @@ impl WasmPool {
         stride: Option<usize>,
         padding: Option<usize>,
     ) -> WasmPool {
-        let mut config = AvgPool1dConfig::new(kernel_size);
-        if let Some(s) = stride {
-            config = config.with_stride(s);
-        }
-        if let Some(p) = padding {
-            config = config.with_padding(PaddingConfig1d::Explicit(p));
-        }
-        WasmPool {
-            inner: PoolingConfig::AvgPool1d(config).init(),
-        }
+        Self::try_new_avg_pool1d(kernel_size, stride, padding).unwrap_or_else(pool_fail)
     }
 
     #[wasm_bindgen(js_name = newAvgPool2d)]
@@ -148,16 +175,15 @@ impl WasmPool {
         padding_h: Option<usize>,
         padding_w: Option<usize>,
     ) -> WasmPool {
-        let mut config = AvgPool2dConfig::new([kernel_size_h, kernel_size_w]);
-        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
-            config = config.with_strides([sh, sw]);
-        }
-        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
-            config = config.with_padding(PaddingConfig2d::Explicit(ph, pw));
-        }
-        WasmPool {
-            inner: PoolingConfig::AvgPool2d(config).init(),
-        }
+        Self::try_new_avg_pool2d(
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+        )
+        .unwrap_or_else(pool_fail)
     }
 
     #[wasm_bindgen(js_name = newAdaptiveAvgPool2d)]
@@ -180,5 +206,140 @@ impl WasmPool {
     // Pooling tidak punya trainable params
     pub fn num_params(&self) -> usize {
         0
+    }
+}
+
+impl WasmPool {
+    pub(crate) fn try_new_max_pool1d(
+        kernel_size: usize,
+        stride: Option<usize>,
+        padding: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_pool1d_params(kernel_size, stride, "MaxPool1d")?;
+        let mut config = MaxPool1dConfig::new(kernel_size);
+        if let Some(s) = stride {
+            config = config.with_stride(s);
+        }
+        if let Some(p) = padding {
+            config = config.with_padding(PaddingConfig1d::Explicit(p));
+        }
+        Ok(WasmPool {
+            inner: PoolingConfig::MaxPool1d(config).init(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_new_max_pool2d(
+        kernel_size_h: usize,
+        kernel_size_w: usize,
+        stride_h: Option<usize>,
+        stride_w: Option<usize>,
+        padding_h: Option<usize>,
+        padding_w: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_pool2d_params(
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            "MaxPool2d",
+        )?;
+        let mut config = MaxPool2dConfig::new([kernel_size_h, kernel_size_w]);
+        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
+            config = config.with_strides([sh, sw]);
+        }
+        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
+            config = config.with_padding(PaddingConfig2d::Explicit(ph, pw));
+        }
+        Ok(WasmPool {
+            inner: PoolingConfig::MaxPool2d(config).init(),
+        })
+    }
+
+    pub(crate) fn try_new_avg_pool1d(
+        kernel_size: usize,
+        stride: Option<usize>,
+        padding: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_pool1d_params(kernel_size, stride, "AvgPool1d")?;
+        let mut config = AvgPool1dConfig::new(kernel_size);
+        if let Some(s) = stride {
+            config = config.with_stride(s);
+        }
+        if let Some(p) = padding {
+            config = config.with_padding(PaddingConfig1d::Explicit(p));
+        }
+        Ok(WasmPool {
+            inner: PoolingConfig::AvgPool1d(config).init(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_new_avg_pool2d(
+        kernel_size_h: usize,
+        kernel_size_w: usize,
+        stride_h: Option<usize>,
+        stride_w: Option<usize>,
+        padding_h: Option<usize>,
+        padding_w: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_pool2d_params(
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            "AvgPool2d",
+        )?;
+        let mut config = AvgPool2dConfig::new([kernel_size_h, kernel_size_w]);
+        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
+            config = config.with_strides([sh, sw]);
+        }
+        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
+            config = config.with_padding(PaddingConfig2d::Explicit(ph, pw));
+        }
+        Ok(WasmPool {
+            inner: PoolingConfig::AvgPool2d(config).init(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_pool1d_params, validate_pool2d_params};
+
+    #[test]
+    fn pool1d_rejects_zero_kernel() {
+        assert!(validate_pool1d_params(0, None, "pool").is_err());
+    }
+
+    #[test]
+    fn pool1d_rejects_zero_explicit_stride() {
+        assert!(validate_pool1d_params(3, Some(0), "pool").is_err());
+    }
+
+    #[test]
+    fn pool1d_accepts_positive_kernel_and_default_stride() {
+        assert!(validate_pool1d_params(3, None, "pool").is_ok());
+    }
+
+    #[test]
+    fn pool2d_rejects_zero_kernel_axis() {
+        assert!(validate_pool2d_params(3, 0, None, None, "pool").is_err());
+    }
+
+    #[test]
+    fn pool2d_rejects_zero_paired_stride_axis() {
+        assert!(validate_pool2d_params(3, 3, Some(1), Some(0), "pool").is_err());
+    }
+
+    #[test]
+    fn pool2d_preserves_partial_stride_behavior() {
+        // Existing wrapper ignores custom stride unless both components are present.
+        assert!(validate_pool2d_params(3, 3, Some(0), None, "pool").is_ok());
+    }
+
+    #[test]
+    fn pool2d_accepts_positive_parameters() {
+        assert!(validate_pool2d_params(3, 5, Some(2), Some(1), "pool").is_ok());
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -296,13 +296,13 @@ impl LayerRegistry {
                 let k = c.read_usize()?;
                 let s = c.read_option_usize()?;
                 let p = c.read_option_usize()?;
-                WasmPool::new_max_pool1d(k, s, p)
+                WasmPool::try_new_max_pool1d(k, s, p)?
             }
             POOL_AVGPOOL1D => {
                 let k = c.read_usize()?;
                 let s = c.read_option_usize()?;
                 let p = c.read_option_usize()?;
-                WasmPool::new_avg_pool1d(k, s, p)
+                WasmPool::try_new_avg_pool1d(k, s, p)?
             }
             POOL_MAXPOOL2D => {
                 let k = c.read_usize()?;
@@ -311,7 +311,7 @@ impl LayerRegistry {
                 let sw = c.read_option_usize()?;
                 let ph = c.read_option_usize()?;
                 let pw = c.read_option_usize()?;
-                WasmPool::new_max_pool2d(k, kw, sh, sw, ph, pw)
+                WasmPool::try_new_max_pool2d(k, kw, sh, sw, ph, pw)?
             }
             POOL_AVGPOOL2D => {
                 let k = c.read_usize()?;
@@ -320,7 +320,7 @@ impl LayerRegistry {
                 let sw = c.read_option_usize()?;
                 let ph = c.read_option_usize()?;
                 let pw = c.read_option_usize()?;
-                WasmPool::new_avg_pool2d(k, kw, sh, sw, ph, pw)
+                WasmPool::try_new_avg_pool2d(k, kw, sh, sw, ph, pw)?
             }
             POOL_ADAPTIVEAVGPOOL2D => {
                 let oh = c.read_usize()?;


### PR DESCRIPTION
Superseded by merged integration PR #28. Pooling parameter guards were reconciled with #21 Pool1d shape guards and passed combined host + WASM CI before #28 was merged.