### PR TITLE
Enforce tensor memory-shape invariants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod tests;
 
 pub type WasmBackend = burn_ndarray::NdArray<f32>;
 
-fn boundary_fail<T>(message: String) -> T {
+fn boundary_fail(message: String) -> ! {
     #[cfg(target_arch = "wasm32")]
     {
         wasm_bindgen::throw_str(&message)
@@ -89,8 +89,10 @@ pub struct WasmTensor {
 impl WasmTensor {
     #[wasm_bindgen(constructor)]
     pub fn new(data: &[f32], shape: &[usize]) -> WasmTensor {
-        let dims = normalize_rank4_shape(shape, "WasmTensor::new").unwrap_or_else(boundary_fail);
-        validate_element_count(dims, data.len(), "WasmTensor::new").unwrap_or_else(boundary_fail);
+        let dims = normalize_rank4_shape(shape, "WasmTensor::new")
+            .unwrap_or_else(|err| boundary_fail(err));
+        validate_element_count(dims, data.len(), "WasmTensor::new")
+            .unwrap_or_else(|err| boundary_fail(err));
 
         let device = Default::default();
         let tensor_data = TensorData::new(data.to_vec(), dims);
@@ -114,7 +116,7 @@ impl WasmTensor {
                     .checked_mul(std::mem::size_of::<f32>())
                     .ok_or_else(|| "WasmTensor::byte_length: byte length overflow".to_string())
             })
-            .unwrap_or_else(boundary_fail)
+            .unwrap_or_else(|err| boundary_fail(err))
     }
 }
 
@@ -131,7 +133,8 @@ pub struct TensorView {
 impl TensorView {
     #[wasm_bindgen(constructor)]
     pub fn new(total_elements: usize) -> Self {
-        let byte_length = checked_sab_byte_length(total_elements).unwrap_or_else(boundary_fail);
+        let byte_length = checked_sab_byte_length(total_elements)
+            .unwrap_or_else(|err| boundary_fail(err));
         let sab = js_sys::SharedArrayBuffer::new(byte_length);
         TensorView {
             sab: JsValue::from(sab),
@@ -146,8 +149,10 @@ impl TensorView {
 
     #[wasm_bindgen(js_name = setShape)]
     pub fn set_shape(&mut self, shape: Vec<usize>) {
-        let dims = normalize_rank4_shape(&shape, "TensorView::setShape").unwrap_or_else(boundary_fail);
-        validate_element_count(dims, self.len(), "TensorView::setShape").unwrap_or_else(boundary_fail);
+        let dims = normalize_rank4_shape(&shape, "TensorView::setShape")
+            .unwrap_or_else(|err| boundary_fail(err));
+        validate_element_count(dims, self.len(), "TensorView::setShape")
+            .unwrap_or_else(|err| boundary_fail(err));
         self.shape = dims.to_vec();
     }
 
@@ -194,9 +199,9 @@ impl WasmTensor {
     #[wasm_bindgen(js_name = fromTensorView)]
     pub fn from_tensor_view(view: &TensorView) -> WasmTensor {
         let dims = normalize_rank4_shape(&view.shape, "WasmTensor::fromTensorView")
-            .unwrap_or_else(boundary_fail);
+            .unwrap_or_else(|err| boundary_fail(err));
         validate_element_count(dims, view.len(), "WasmTensor::fromTensorView")
-            .unwrap_or_else(boundary_fail);
+            .unwrap_or_else(|err| boundary_fail(err));
 
         let mut buf = vec![0f32; view.len()];
         view.read(&mut buf);
@@ -212,7 +217,7 @@ impl WasmTensor {
     pub fn to_tensor_view(&self, view: &mut TensorView) {
         let dims = self.inner.dims();
         validate_element_count(dims, view.len(), "WasmTensor::toTensorView")
-            .unwrap_or_else(boundary_fail);
+            .unwrap_or_else(|err| boundary_fail(err));
 
         let data = self.inner.to_data();
         let slice = data.as_slice::<f32>().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,80 @@
-use wasm_bindgen::prelude::*;
 use burn::prelude::*;
 use burn::tensor::TensorData;
 use js_sys::Float32Array;
+use wasm_bindgen::prelude::*;
 
+pub mod es;
+pub mod graph;
 pub mod layers;
 pub mod protocol;
 pub mod registry;
-pub mod es;
-pub mod graph;
 #[cfg(test)]
 mod tests;
 
 pub type WasmBackend = burn_ndarray::NdArray<f32>;
+
+fn boundary_fail<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
+
+fn normalize_rank4_shape(shape: &[usize], context: &str) -> Result<[usize; 4], String> {
+    if shape.len() > 4 {
+        return Err(format!(
+            "{context}: rank {} exceeds the 4D tensor bridge",
+            shape.len()
+        ));
+    }
+
+    let mut dims = [1usize; 4];
+    for (index, &dim) in shape.iter().enumerate() {
+        dims[index] = dim;
+    }
+
+    checked_element_count(dims, context)?;
+    Ok(dims)
+}
+
+fn checked_element_count(dims: [usize; 4], context: &str) -> Result<usize, String> {
+    dims.into_iter().try_fold(1usize, |count, dim| {
+        count
+            .checked_mul(dim)
+            .ok_or_else(|| format!("{context}: shape element count overflow for {dims:?}"))
+    })
+}
+
+fn validate_element_count(
+    dims: [usize; 4],
+    actual: usize,
+    context: &str,
+) -> Result<(), String> {
+    let expected = checked_element_count(dims, context)?;
+    if actual != expected {
+        return Err(format!(
+            "{context}: shape {dims:?} requires {expected} elements, got {actual}"
+        ));
+    }
+    Ok(())
+}
+
+fn checked_sab_byte_length(total_elements: usize) -> Result<u32, String> {
+    let bytes = total_elements
+        .checked_mul(std::mem::size_of::<f32>())
+        .ok_or_else(|| "TensorView: byte length overflow".to_string())?;
+    u32::try_from(bytes).map_err(|_| {
+        format!(
+            "TensorView: {} elements require {} bytes, exceeding SharedArrayBuffer u32 length",
+            total_elements, bytes
+        )
+    })
+}
 
 // -------------------------------------------------------------
 // WASM TENSOR — 4D tensor bridge
@@ -19,18 +82,17 @@ pub type WasmBackend = burn_ndarray::NdArray<f32>;
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct WasmTensor {
-    pub(crate) inner: Tensor<WasmBackend, 4>, 
+    pub(crate) inner: Tensor<WasmBackend, 4>,
 }
 
 #[wasm_bindgen]
 impl WasmTensor {
     #[wasm_bindgen(constructor)]
     pub fn new(data: &[f32], shape: &[usize]) -> WasmTensor {
+        let dims = normalize_rank4_shape(shape, "WasmTensor::new").unwrap_or_else(boundary_fail);
+        validate_element_count(dims, data.len(), "WasmTensor::new").unwrap_or_else(boundary_fail);
+
         let device = Default::default();
-        let mut dims = [1usize, 1, 1, 1];
-        for (i, &d) in shape.iter().enumerate().take(4) {
-            dims[i] = d;
-        }
         let tensor_data = TensorData::new(data.to_vec(), dims);
         let tensor = Tensor::from_data(tensor_data, &device);
         WasmTensor { inner: tensor }
@@ -46,7 +108,13 @@ impl WasmTensor {
     }
 
     pub fn byte_length(&self) -> usize {
-        self.inner.dims().iter().product::<usize>() * 4 
+        checked_element_count(self.inner.dims(), "WasmTensor::byte_length")
+            .and_then(|count| {
+                count
+                    .checked_mul(std::mem::size_of::<f32>())
+                    .ok_or_else(|| "WasmTensor::byte_length: byte length overflow".to_string())
+            })
+            .unwrap_or_else(boundary_fail)
     }
 }
 
@@ -63,10 +131,11 @@ pub struct TensorView {
 impl TensorView {
     #[wasm_bindgen(constructor)]
     pub fn new(total_elements: usize) -> Self {
-        let sab = js_sys::SharedArrayBuffer::new((total_elements * 4) as u32);
-        TensorView { 
-            sab: JsValue::from(sab), 
-            shape: vec![1, 1, 1, 1] 
+        let byte_length = checked_sab_byte_length(total_elements).unwrap_or_else(boundary_fail);
+        let sab = js_sys::SharedArrayBuffer::new(byte_length);
+        TensorView {
+            sab: JsValue::from(sab),
+            shape: vec![total_elements, 1, 1, 1],
         }
     }
 
@@ -77,7 +146,9 @@ impl TensorView {
 
     #[wasm_bindgen(js_name = setShape)]
     pub fn set_shape(&mut self, shape: Vec<usize>) {
-        self.shape = shape;
+        let dims = normalize_rank4_shape(&shape, "TensorView::setShape").unwrap_or_else(boundary_fail);
+        validate_element_count(dims, self.len(), "TensorView::setShape").unwrap_or_else(boundary_fail);
+        self.shape = dims.to_vec();
     }
 
     pub fn shape(&self) -> Vec<usize> {
@@ -90,12 +161,26 @@ impl TensorView {
 
     /// Copy data dari SAB ke slice Rust (Rust baca data JS)
     pub fn read(&self, dst: &mut [f32]) {
+        if dst.len() != self.len() {
+            boundary_fail(format!(
+                "TensorView::read: destination length {} does not match view length {}",
+                dst.len(),
+                self.len()
+            ));
+        }
         let arr = self.as_f32_array();
         arr.copy_to(dst);
     }
 
     /// Copy data dari slice Rust ke SAB (Rust tulis data untuk JS)
     pub fn write(&self, src: &[f32]) {
+        if src.len() != self.len() {
+            boundary_fail(format!(
+                "TensorView::write: source length {} does not match view length {}",
+                src.len(),
+                self.len()
+            ));
+        }
         let arr = self.as_f32_array();
         arr.copy_from(src);
     }
@@ -108,25 +193,73 @@ impl TensorView {
 impl WasmTensor {
     #[wasm_bindgen(js_name = fromTensorView)]
     pub fn from_tensor_view(view: &TensorView) -> WasmTensor {
-        let device = Default::default();
-        let mut dims = [1usize; 4];
-        for (i, &d) in view.shape().iter().enumerate().take(4) {
-            dims[i] = d;
-        }
+        let dims = normalize_rank4_shape(&view.shape, "WasmTensor::fromTensorView")
+            .unwrap_or_else(boundary_fail);
+        validate_element_count(dims, view.len(), "WasmTensor::fromTensorView")
+            .unwrap_or_else(boundary_fail);
 
         let mut buf = vec![0f32; view.len()];
         view.read(&mut buf);
 
+        let device = Default::default();
         let tensor_data = TensorData::new(buf, dims);
-        WasmTensor { inner: Tensor::from_data(tensor_data, &device) }
+        WasmTensor {
+            inner: Tensor::from_data(tensor_data, &device),
+        }
     }
 
     #[wasm_bindgen(js_name = toTensorView)]
     pub fn to_tensor_view(&self, view: &mut TensorView) {
+        let dims = self.inner.dims();
+        validate_element_count(dims, view.len(), "WasmTensor::toTensorView")
+            .unwrap_or_else(boundary_fail);
+
         let data = self.inner.to_data();
         let slice = data.as_slice::<f32>().unwrap();
         view.write(slice);
-        view.set_shape(self.inner.dims().into());
+        view.set_shape(dims.into());
     }
 }
 
+#[cfg(test)]
+mod tensor_boundary_tests {
+    use super::{
+        checked_element_count, checked_sab_byte_length, normalize_rank4_shape,
+        validate_element_count,
+    };
+
+    #[test]
+    fn rank4_shape_pads_short_shapes_with_singletons() {
+        assert_eq!(
+            normalize_rank4_shape(&[2, 3], "test").unwrap(),
+            [2, 3, 1, 1]
+        );
+    }
+
+    #[test]
+    fn rank4_shape_rejects_hidden_fifth_axis() {
+        assert!(normalize_rank4_shape(&[1, 2, 3, 4, 5], "test").is_err());
+    }
+
+    #[test]
+    fn element_count_rejects_shape_overflow() {
+        assert!(checked_element_count([usize::MAX, 2, 1, 1], "test").is_err());
+    }
+
+    #[test]
+    fn element_count_rejects_buffer_mismatch() {
+        let err = validate_element_count([2, 3, 1, 1], 5, "test").unwrap_err();
+        assert!(err.contains("requires 6 elements"));
+    }
+
+    #[test]
+    fn sab_byte_length_rejects_u32_overflow() {
+        let too_many = (u32::MAX as usize / std::mem::size_of::<f32>()) + 1;
+        assert!(checked_sab_byte_length(too_many).is_err());
+    }
+
+    #[test]
+    fn sab_byte_length_accepts_representable_capacity() {
+        assert_eq!(checked_sab_byte_length(1024).unwrap(), 4096);
+    }
+}


### PR DESCRIPTION
## Tujuan
Menjadikan boundary tensor 4D dan SharedArrayBuffer konsisten secara matematis: `product(shape) == element_count == buffer length` sebelum data masuk ke Burn atau js-sys copy path.

## Masalah yang ditutup
- `WasmTensor::new()` sebelumnya memotong shape >4D secara diam-diam dan tidak memverifikasi `data.len()` terhadap product shape
- `TensorView::new(N)` sebelumnya langsung memiliki shape `[1,1,1,1]` walau buffer berisi N elemen
- `TensorView::setShape()` menerima shape arbitrary tanpa cardinality check
- `fromTensorView()` dapat membangun tensor dari buffer dan shape yang jumlah elemennya berbeda
- `toTensorView()` dapat menulis tensor ke view dengan kapasitas yang tidak cocok
- ukuran SharedArrayBuffer sebelumnya menghitung `total_elements * 4` lalu cast ke `u32` tanpa overflow/range guard

## Perubahan
- canonical rank-4 normalization dengan rejection untuk hidden axis ke-5+
- checked shape product dan exact element-count validation
- `TensorView::new(N)` mulai dalam state konsisten `[N,1,1,1]`
- `setShape()` menyimpan shape canonical 4D hanya jika product sama dengan kapasitas view
- `read()`/`write()` memerlukan exact slice length sebelum js-sys copy
- `fromTensorView()` dan `toTensorView()` memvalidasi cardinality sebelum allocation/copy
- SharedArrayBuffer byte length memakai checked multiplication + u32 range guard
- signature valid-path publik dipertahankan; invalid input menjadi exception pada WASM sebelum backend
- tambah 6 host unit tests untuk validator murni

## Invariant yang dipertahankan
- valid tensor 4D dan short-shape yang dapat dipad dengan singleton tetap menghasilkan layout data yang sama
- data order tidak berubah
- backend tetap `burn_ndarray::NdArray<f32>`
- graph/layer/registry/ES tidak disentuh

## Independensi
Branch dibuat langsung dari `main`; diff hanya `src/lib.rs`.