### PR TITLE
Unify and harden protocol read invariants

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -291,25 +291,32 @@ impl<'a> PayloadCursor<'a> {
 // HELPER: read/write multi-byte dari payload
 // ============================================================
 
+fn checked_read_range<'a>(
+    payload: &'a [u8],
+    offset: usize,
+    width: usize,
+    context: &str,
+) -> Result<&'a [u8], String> {
+    let end = offset
+        .checked_add(width)
+        .ok_or_else(|| format!("{context} offset overflow"))?;
+    payload
+        .get(offset..end)
+        .ok_or_else(|| format!("{context} out of bounds"))
+}
+
 pub fn read_u32(payload: &[u8], offset: usize) -> Result<u32, String> {
-    if offset + 4 > payload.len() {
-        return Err("read_u32 out of bounds".into());
-    }
+    let bytes = checked_read_range(payload, offset, 4, "read_u32")?;
     Ok(u32::from_le_bytes([
-        payload[offset],
-        payload[offset + 1],
-        payload[offset + 2],
-        payload[offset + 3],
+        bytes[0], bytes[1], bytes[2], bytes[3],
     ]))
 }
 
 pub fn read_f64(payload: &[u8], offset: usize) -> Result<f64, String> {
-    if offset + 8 > payload.len() {
-        return Err("read_f64 out of bounds".into());
-    }
+    let bytes = checked_read_range(payload, offset, 8, "read_f64")?;
     Ok(f64::from_le_bytes([
-        payload[offset], payload[offset + 1], payload[offset + 2], payload[offset + 3],
-        payload[offset + 4], payload[offset + 5], payload[offset + 6], payload[offset + 7],
+        bytes[0], bytes[1], bytes[2], bytes[3],
+        bytes[4], bytes[5], bytes[6], bytes[7],
     ]))
 }
 
@@ -318,30 +325,74 @@ pub fn read_usize(payload: &[u8], offset: usize) -> Result<usize, String> {
 }
 
 pub fn read_bool(payload: &[u8], offset: usize) -> Result<bool, String> {
-    if offset >= payload.len() {
-        return Err("read_bool out of bounds".into());
-    }
-    Ok(payload[offset] != 0)
+    payload
+        .get(offset)
+        .copied()
+        .map(|v| v != 0)
+        .ok_or_else(|| "read_bool out of bounds".into())
 }
 
 pub fn read_option_u32(payload: &[u8], offset: usize) -> Result<Option<u32>, String> {
-    if offset >= payload.len() {
-        return Err("read_option out of bounds".into());
-    }
-    if payload[offset] == 0 {
+    let present = payload
+        .get(offset)
+        .copied()
+        .ok_or_else(|| "read_option out of bounds".to_string())?;
+    if present == 0 {
         Ok(None)
     } else {
-        read_u32(payload, offset + 1).map(Some)
+        let value_offset = offset
+            .checked_add(1)
+            .ok_or_else(|| "read_option offset overflow".to_string())?;
+        read_u32(payload, value_offset).map(Some)
     }
 }
 
 pub fn read_option_f64(payload: &[u8], offset: usize) -> Result<Option<f64>, String> {
-    if offset >= payload.len() {
-        return Err("read_option out of bounds".into());
-    }
-    if payload[offset] == 0 {
+    let present = payload
+        .get(offset)
+        .copied()
+        .ok_or_else(|| "read_option out of bounds".to_string())?;
+    if present == 0 {
         Ok(None)
     } else {
-        read_f64(payload, offset + 1).map(Some)
+        let value_offset = offset
+            .checked_add(1)
+            .ok_or_else(|| "read_option offset overflow".to_string())?;
+        read_f64(payload, value_offset).map(Some)
+    }
+}
+
+#[cfg(test)]
+mod offset_tests {
+    use super::{read_f64, read_option_f64, read_option_u32, read_u32};
+
+    #[test]
+    fn read_u32_rejects_offset_overflow_without_panicking() {
+        let err = read_u32(&[0u8; 8], usize::MAX).unwrap_err();
+        assert!(err.contains("offset overflow"));
+    }
+
+    #[test]
+    fn read_f64_rejects_offset_overflow_without_panicking() {
+        let err = read_f64(&[0u8; 8], usize::MAX).unwrap_err();
+        assert!(err.contains("offset overflow"));
+    }
+
+    #[test]
+    fn fixed_width_reader_rejects_truncated_range() {
+        assert!(read_u32(&[1, 2, 3], 0).is_err());
+        assert!(read_f64(&[0u8; 7], 0).is_err());
+    }
+
+    #[test]
+    fn option_readers_preserve_none_without_value_bytes() {
+        assert_eq!(read_option_u32(&[0], 0).unwrap(), None);
+        assert_eq!(read_option_f64(&[0], 0).unwrap(), None);
+    }
+
+    #[test]
+    fn option_readers_reject_present_value_when_truncated() {
+        assert!(read_option_u32(&[1, 0, 0], 0).is_err());
+        assert!(read_option_f64(&[1, 0, 0, 0], 0).is_err());
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -333,38 +333,27 @@ pub fn read_bool(payload: &[u8], offset: usize) -> Result<bool, String> {
 }
 
 pub fn read_option_u32(payload: &[u8], offset: usize) -> Result<Option<u32>, String> {
-    let present = payload
-        .get(offset)
-        .copied()
-        .ok_or_else(|| "read_option out of bounds".to_string())?;
-    if present == 0 {
-        Ok(None)
-    } else {
-        let value_offset = offset
-            .checked_add(1)
-            .ok_or_else(|| "read_option offset overflow".to_string())?;
-        read_u32(payload, value_offset).map(Some)
-    }
+    let bytes = checked_read_range(payload, offset, 5, "read_option_u32")?;
+    let present = bytes[0] != 0;
+    let value = u32::from_le_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]);
+    Ok(if present { Some(value) } else { None })
 }
 
 pub fn read_option_f64(payload: &[u8], offset: usize) -> Result<Option<f64>, String> {
-    let present = payload
-        .get(offset)
-        .copied()
-        .ok_or_else(|| "read_option out of bounds".to_string())?;
-    if present == 0 {
-        Ok(None)
-    } else {
-        let value_offset = offset
-            .checked_add(1)
-            .ok_or_else(|| "read_option offset overflow".to_string())?;
-        read_f64(payload, value_offset).map(Some)
-    }
+    let bytes = checked_read_range(payload, offset, 9, "read_option_f64")?;
+    let present = bytes[0] != 0;
+    let value = f64::from_le_bytes([
+        bytes[1], bytes[2], bytes[3], bytes[4],
+        bytes[5], bytes[6], bytes[7], bytes[8],
+    ]);
+    Ok(if present { Some(value) } else { None })
 }
 
 #[cfg(test)]
 mod offset_tests {
-    use super::{read_f64, read_option_f64, read_option_u32, read_u32};
+    use super::{
+        read_f64, read_option_f64, read_option_u32, read_u32, PayloadCursor,
+    };
 
     #[test]
     fn read_u32_rejects_offset_overflow_without_panicking() {
@@ -385,14 +374,39 @@ mod offset_tests {
     }
 
     #[test]
-    fn option_readers_preserve_none_without_value_bytes() {
-        assert_eq!(read_option_u32(&[0], 0).unwrap(), None);
-        assert_eq!(read_option_f64(&[0], 0).unwrap(), None);
+    fn option_u32_matches_cursor_fixed_width_none() {
+        assert!(read_option_u32(&[0], 0).is_err());
+        let bytes = [0, 0, 0, 0, 0];
+        assert_eq!(read_option_u32(&bytes, 0).unwrap(), None);
+        let mut cursor = PayloadCursor::new(&bytes);
+        assert_eq!(cursor.read_option_u32().unwrap(), None);
+        assert_eq!(cursor.remaining(), 0);
     }
 
     #[test]
-    fn option_readers_reject_present_value_when_truncated() {
-        assert!(read_option_u32(&[1, 0, 0], 0).is_err());
-        assert!(read_option_f64(&[1, 0, 0, 0], 0).is_err());
+    fn option_f64_matches_cursor_fixed_width_none() {
+        assert!(read_option_f64(&[0], 0).is_err());
+        let bytes = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(read_option_f64(&bytes, 0).unwrap(), None);
+        let mut cursor = PayloadCursor::new(&bytes);
+        assert_eq!(cursor.read_option_f64().unwrap(), None);
+        assert_eq!(cursor.remaining(), 0);
+    }
+
+    #[test]
+    fn option_readers_decode_present_values() {
+        let mut u32_bytes = vec![1];
+        u32_bytes.extend_from_slice(&42u32.to_le_bytes());
+        assert_eq!(read_option_u32(&u32_bytes, 0).unwrap(), Some(42));
+
+        let mut f64_bytes = vec![1];
+        f64_bytes.extend_from_slice(&3.5f64.to_le_bytes());
+        assert_eq!(read_option_f64(&f64_bytes, 0).unwrap(), Some(3.5));
+    }
+
+    #[test]
+    fn option_readers_reject_offset_overflow() {
+        assert!(read_option_u32(&[0u8; 5], usize::MAX).is_err());
+        assert!(read_option_f64(&[0u8; 9], usize::MAX).is_err());
     }
 }


### PR DESCRIPTION
## Tujuan
Menutup panic surface pada helper reader protocol sekaligus menghilangkan dual-dialect `Option` antara free readers dan `PayloadCursor`, tanpa mengubah endian atau packet header.

## Masalah yang ditutup
- `read_u32()` / `read_f64()` sebelumnya dapat overflow pada `offset + width`
- free `read_option_u32/f64()` sebelumnya mengizinkan `None` hanya dengan 1 byte tag, sedangkan `PayloadCursor` memakai layout fixed-size `tag + value bytes`
- dua parser untuk wire-format yang sama dapat mengonsumsi jumlah byte berbeda

## Perubahan
- fixed-width reads memakai checked range arithmetic sebelum indexing
- `read_bool()` memakai safe indexed access
- free `read_option_u32()` sekarang selalu membaca tepat 5 byte: 1 tag + 4 value bytes
- free `read_option_f64()` sekarang selalu membaca tepat 9 byte: 1 tag + 8 value bytes
- tag nol tetap menghasilkan `None`, tetapi dummy value bytes tetap dikonsumsi seperti `PayloadCursor`
- tambah regression tests untuk overflow, truncation, canonical `None`, `Some`, dan kesetaraan consumption dengan cursor

## Invariant yang dipertahankan
- little-endian encoding tidak berubah
- tag nonzero tetap berarti `Some`
- `PayloadCursor` sendiri tidak diubah
- registry/graph/layers tidak berubah
- payload valid canonical menghasilkan nilai yang sama

## Integrasi
PR ini merupakan implementasi protocol boundary yang lebih terisolasi daripada #16: semantik canonical #16 dipertahankan, tetapi perubahan tetap hanya di `src/protocol.rs`, sehingga tidak menambah konflik `src/lib.rs`.