### PR TITLE
Integrate remaining layer and registry hardening

### DIFF
--- a/src/layers/activation.rs
+++ b/src/layers/activation.rs
@@ -8,6 +8,37 @@ use burn::record::{BinBytesRecorder, FullPrecisionSettings, Recorder};
 use wasm_bindgen::prelude::*;
 use crate::{WasmBackend, WasmTensor};
 
+fn validate_rank4_axis(dim: usize, context: &str) -> Result<(), String> {
+    if dim >= 4 {
+        return Err(format!("{context}: dim must be in 0..4, got {dim}"));
+    }
+    Ok(())
+}
+
+fn validate_glu_shape(shape: [usize; 4], dim: usize) -> Result<(), String> {
+    validate_rank4_axis(dim, "GLU forward")?;
+    let n = shape[dim];
+    if n % 2 != 0 {
+        return Err(format!(
+            "GLU forward: axis {dim} size must be divisible by 2, got {n} for shape {:?}",
+            shape
+        ));
+    }
+    Ok(())
+}
+
+fn activation_forward_fail<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
+
 // --- HELPER STRUCTS (SOLUSI ERROR DERIVE) ---
 #[derive(Module, Debug, Clone)]
 pub struct StrictSoftmax {
@@ -246,9 +277,7 @@ impl WasmActivation {
     }
 
     pub fn forward(&self, input: &WasmTensor) -> WasmTensor {
-        let x = input.inner.clone();
-        let out = self.inner.forward(x);
-        WasmTensor { inner: out }
+        self.try_forward(input).unwrap_or_else(activation_forward_fail)
     }
 
     pub fn num_params(&self) -> usize {
@@ -270,5 +299,54 @@ impl WasmActivation {
             .record(record, ())
             .map_err(|e| e.to_string())?;
         Ok(bytes)
+    }
+}
+
+impl WasmActivation {
+    pub(crate) fn try_forward(&self, input: &WasmTensor) -> Result<WasmTensor, String> {
+        let shape = input.inner.dims();
+        match &self.inner {
+            Activation::Softmax(m) => validate_rank4_axis(m.dim, "Softmax forward")?,
+            Activation::LogSoftmax(m) => validate_rank4_axis(m.dim, "LogSoftmax forward")?,
+            Activation::Glu(m) => validate_glu_shape(shape, m.dim)?,
+            _ => {}
+        }
+
+        let out = self.inner.forward(input.inner.clone());
+        Ok(WasmTensor { inner: out })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_glu_shape, validate_rank4_axis};
+
+    #[test]
+    fn rank4_axis_accepts_valid_dimensions() {
+        for dim in 0..4 {
+            assert!(validate_rank4_axis(dim, "test").is_ok());
+        }
+    }
+
+    #[test]
+    fn rank4_axis_rejects_out_of_range_dimension() {
+        let err = validate_rank4_axis(4, "Softmax forward").unwrap_err();
+        assert!(err.contains("0..4"));
+    }
+
+    #[test]
+    fn glu_accepts_even_axis_size() {
+        assert!(validate_glu_shape([2, 8, 3, 1], 1).is_ok());
+    }
+
+    #[test]
+    fn glu_rejects_odd_axis_size() {
+        let err = validate_glu_shape([2, 7, 3, 1], 1).unwrap_err();
+        assert!(err.contains("divisible by 2"));
+    }
+
+    #[test]
+    fn glu_rejects_out_of_range_axis() {
+        assert!(validate_glu_shape([2, 8, 3, 1], 4).is_err());
     }
 }

--- a/src/layers/conv.rs
+++ b/src/layers/conv.rs
@@ -9,6 +9,42 @@ use wasm_bindgen::prelude::*;
 use crate::{WasmBackend, WasmTensor};
 use crate::layers::shape_contract::require_singleton_axis;
 
+fn validate_conv1d_stride(stride: Option<usize>, context: &str) -> Result<(), String> {
+    if stride == Some(0) {
+        return Err(format!("{context}: stride must be greater than 0"));
+    }
+    Ok(())
+}
+
+fn validate_conv2d_stride(
+    stride_h: Option<usize>,
+    stride_w: Option<usize>,
+    context: &str,
+) -> Result<(), String> {
+    // Preserve the existing wrapper contract: a custom 2D stride is applied only when both
+    // components are present. A partial pair is ignored and leaves Burn's [1, 1] default intact.
+    if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
+        if sh == 0 || sw == 0 {
+            return Err(format!(
+                "{context}: strides must be greater than 0, got [{sh}, {sw}]"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn conv_fail<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
+
 // --- CONFIGURATION ENUM ---
 #[derive(Config, Debug)]
 pub enum ConvolutionConfig {
@@ -67,17 +103,8 @@ impl WasmConv {
         stride: Option<usize>,
         padding: Option<usize>,
     ) -> WasmConv {
-        let device = Default::default();
-        let mut config = Conv1dConfig::new(in_channels, out_channels, kernel_size);
-        if let Some(s) = stride {
-            config.stride = s;
-        }
-        if let Some(p) = padding {
-            config.padding = burn::nn::PaddingConfig1d::Explicit(p);
-        }
-        WasmConv {
-            inner: ConvolutionConfig::Conv1d(config).init(&device),
-        }
+        Self::try_new_conv1d(in_channels, out_channels, kernel_size, stride, padding)
+            .unwrap_or_else(conv_fail)
     }
 
     #[wasm_bindgen(js_name = newConv2d)]
@@ -91,17 +118,17 @@ impl WasmConv {
         padding_h: Option<usize>,
         padding_w: Option<usize>,
     ) -> WasmConv {
-        let device = Default::default();
-        let mut config = Conv2dConfig::new([in_channels, out_channels], [kernel_size_h, kernel_size_w]);
-        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
-            config.stride = [sh, sw];
-        }
-        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
-            config.padding = burn::nn::PaddingConfig2d::Explicit(ph, pw);
-        }
-        WasmConv {
-            inner: ConvolutionConfig::Conv2d(config).init(&device),
-        }
+        Self::try_new_conv2d(
+            in_channels,
+            out_channels,
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+        )
+        .unwrap_or_else(conv_fail)
     }
 
     #[wasm_bindgen(js_name = newConvTranspose2d)]
@@ -115,17 +142,17 @@ impl WasmConv {
         padding_h: Option<usize>,
         padding_w: Option<usize>,
     ) -> WasmConv {
-        let device = Default::default();
-        let mut config = ConvTranspose2dConfig::new([in_channels, out_channels], [kernel_size_h, kernel_size_w]);
-        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
-            config.stride = [sh, sw];
-        }
-        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
-            config.padding = [ph, pw];
-        }
-        WasmConv {
-            inner: ConvolutionConfig::ConvTranspose2d(config).init(&device),
-        }
+        Self::try_new_conv_transpose2d(
+            in_channels,
+            out_channels,
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+        )
+        .unwrap_or_else(conv_fail)
     }
 
     pub fn forward(&self, input: &WasmTensor) -> WasmTensor {
@@ -156,6 +183,77 @@ impl WasmConv {
 }
 
 impl WasmConv {
+    pub(crate) fn try_new_conv1d(
+        in_channels: usize,
+        out_channels: usize,
+        kernel_size: usize,
+        stride: Option<usize>,
+        padding: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_conv1d_stride(stride, "Conv1d")?;
+        let device = Default::default();
+        let mut config = Conv1dConfig::new(in_channels, out_channels, kernel_size);
+        if let Some(s) = stride {
+            config.stride = s;
+        }
+        if let Some(p) = padding {
+            config.padding = burn::nn::PaddingConfig1d::Explicit(p);
+        }
+        Ok(WasmConv {
+            inner: ConvolutionConfig::Conv1d(config).init(&device),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_new_conv2d(
+        in_channels: usize,
+        out_channels: usize,
+        kernel_size_h: usize,
+        kernel_size_w: usize,
+        stride_h: Option<usize>,
+        stride_w: Option<usize>,
+        padding_h: Option<usize>,
+        padding_w: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_conv2d_stride(stride_h, stride_w, "Conv2d")?;
+        let device = Default::default();
+        let mut config = Conv2dConfig::new([in_channels, out_channels], [kernel_size_h, kernel_size_w]);
+        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
+            config.stride = [sh, sw];
+        }
+        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
+            config.padding = burn::nn::PaddingConfig2d::Explicit(ph, pw);
+        }
+        Ok(WasmConv {
+            inner: ConvolutionConfig::Conv2d(config).init(&device),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_new_conv_transpose2d(
+        in_channels: usize,
+        out_channels: usize,
+        kernel_size_h: usize,
+        kernel_size_w: usize,
+        stride_h: Option<usize>,
+        stride_w: Option<usize>,
+        padding_h: Option<usize>,
+        padding_w: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_conv2d_stride(stride_h, stride_w, "ConvTranspose2d")?;
+        let device = Default::default();
+        let mut config = ConvTranspose2dConfig::new([in_channels, out_channels], [kernel_size_h, kernel_size_w]);
+        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
+            config.stride = [sh, sw];
+        }
+        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
+            config.padding = [ph, pw];
+        }
+        Ok(WasmConv {
+            inner: ConvolutionConfig::ConvTranspose2d(config).init(&device),
+        })
+    }
+
     pub(crate) fn try_forward(&self, input: &WasmTensor) -> Result<WasmTensor, String> {
         if matches!(&self.inner, Convolution::Conv1d(_)) {
             require_singleton_axis(input.inner.dims(), 3, "Conv1d forward")?;
@@ -292,5 +390,39 @@ impl WasmConv {
 
     pub fn weight_layout(&self) -> String {
         crate::layers::layout::segs_json(&self.weight_segs())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_conv1d_stride, validate_conv2d_stride};
+
+    #[test]
+    fn conv1d_rejects_zero_explicit_stride() {
+        assert!(validate_conv1d_stride(Some(0), "Conv1d").is_err());
+    }
+
+    #[test]
+    fn conv1d_accepts_default_and_positive_stride() {
+        assert!(validate_conv1d_stride(None, "Conv1d").is_ok());
+        assert!(validate_conv1d_stride(Some(2), "Conv1d").is_ok());
+    }
+
+    #[test]
+    fn conv2d_rejects_zero_paired_stride_axis() {
+        assert!(validate_conv2d_stride(Some(0), Some(1), "Conv2d").is_err());
+        assert!(validate_conv2d_stride(Some(1), Some(0), "Conv2d").is_err());
+    }
+
+    #[test]
+    fn conv2d_preserves_partial_stride_behavior() {
+        assert!(validate_conv2d_stride(Some(0), None, "Conv2d").is_ok());
+        assert!(validate_conv2d_stride(None, Some(0), "Conv2d").is_ok());
+    }
+
+    #[test]
+    fn conv2d_accepts_default_and_positive_stride() {
+        assert!(validate_conv2d_stride(None, None, "Conv2d").is_ok());
+        assert!(validate_conv2d_stride(Some(2), Some(3), "Conv2d").is_ok());
     }
 }

--- a/src/layers/norm.rs
+++ b/src/layers/norm.rs
@@ -7,6 +7,52 @@ use burn::record::{BinBytesRecorder, FullPrecisionSettings, Recorder};
 use wasm_bindgen::prelude::*;
 use crate::{WasmBackend, WasmTensor};
 
+fn validate_group_config(num_groups: usize, num_channels: usize) -> Result<(), String> {
+    if num_groups == 0 {
+        return Err("GroupNorm: num_groups must be greater than 0".to_string());
+    }
+    if num_channels % num_groups != 0 {
+        return Err(format!(
+            "GroupNorm: num_channels ({num_channels}) must be divisible by num_groups ({num_groups})"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_rms_epsilon(epsilon: f64) -> Result<(), String> {
+    if !(epsilon > 0.0) {
+        return Err(format!("RMSNorm: epsilon must be positive, got {epsilon}"));
+    }
+    Ok(())
+}
+
+fn validate_norm_axis(
+    shape: [usize; 4],
+    axis: usize,
+    expected: usize,
+    context: &str,
+) -> Result<(), String> {
+    if shape[axis] != expected {
+        return Err(format!(
+            "{context}: expected axis {axis} size {expected}, got {} for shape {:?}",
+            shape[axis], shape
+        ));
+    }
+    Ok(())
+}
+
+fn norm_fail<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
+
 // --- CONFIG ENUM ---
 #[derive(Config, Debug)]
 pub enum NormalizationConfig {
@@ -61,10 +107,7 @@ pub struct WasmNorm {
 impl WasmNorm {
     #[wasm_bindgen]
     pub fn new_rms_norm(size: usize, epsilon: Option<f64>) -> WasmNorm {
-        let device = Default::default();
-        let eps = epsilon.unwrap_or(1e-5);
-        let config = NormalizationConfig::Rms(RmsNormConfig::new(size).with_epsilon(eps));
-        WasmNorm { inner: config.init(&device) }
+        Self::try_new_rms_norm(size, epsilon).unwrap_or_else(norm_fail)
     }
 
     #[wasm_bindgen]
@@ -85,10 +128,7 @@ impl WasmNorm {
 
     #[wasm_bindgen]
     pub fn new_group_norm(num_groups: usize, num_channels: usize, epsilon: Option<f64>) -> WasmNorm {
-        let device = Default::default();
-        let eps = epsilon.unwrap_or(1e-5);
-        let config = NormalizationConfig::Group(GroupNormConfig::new(num_groups, num_channels).with_epsilon(eps));
-        WasmNorm { inner: config.init(&device) }
+        Self::try_new_group_norm(num_groups, num_channels, epsilon).unwrap_or_else(norm_fail)
     }
 
     #[wasm_bindgen]
@@ -100,9 +140,7 @@ impl WasmNorm {
     }
 
     pub fn forward(&self, input: &WasmTensor) -> WasmTensor {
-        let x = input.inner.clone();
-        let out = self.inner.forward(x);
-        WasmTensor { inner: out }
+        self.try_forward(input).unwrap_or_else(norm_fail)
     }
 
     pub fn num_params(&self) -> usize {
@@ -128,6 +166,55 @@ impl WasmNorm {
         Ok(bytes)
     }
 }
+
+impl WasmNorm {
+    pub(crate) fn try_new_rms_norm(size: usize, epsilon: Option<f64>) -> Result<Self, String> {
+        let device = Default::default();
+        let eps = epsilon.unwrap_or(1e-5);
+        validate_rms_epsilon(eps)?;
+        let config = NormalizationConfig::Rms(RmsNormConfig::new(size).with_epsilon(eps));
+        Ok(WasmNorm { inner: config.init(&device) })
+    }
+
+    pub(crate) fn try_new_group_norm(
+        num_groups: usize,
+        num_channels: usize,
+        epsilon: Option<f64>,
+    ) -> Result<Self, String> {
+        validate_group_config(num_groups, num_channels)?;
+        let device = Default::default();
+        let eps = epsilon.unwrap_or(1e-5);
+        let config = NormalizationConfig::Group(
+            GroupNormConfig::new(num_groups, num_channels).with_epsilon(eps),
+        );
+        Ok(WasmNorm { inner: config.init(&device) })
+    }
+
+    pub(crate) fn try_forward(&self, input: &WasmTensor) -> Result<WasmTensor, String> {
+        let shape = input.inner.dims();
+        match &self.inner {
+            Normalization::Batch(norm) => {
+                validate_norm_axis(shape, 1, norm.gamma.dims()[0], "BatchNorm forward")?;
+            }
+            Normalization::Group(norm) => {
+                validate_norm_axis(shape, 1, norm.num_channels, "GroupNorm forward")?;
+            }
+            Normalization::Instance(norm) => {
+                validate_norm_axis(shape, 1, norm.num_channels, "InstanceNorm forward")?;
+            }
+            Normalization::Layer(norm) => {
+                validate_norm_axis(shape, 3, norm.gamma.dims()[0], "LayerNorm forward")?;
+            }
+            Normalization::Rms(norm) => {
+                validate_norm_axis(shape, 3, norm.gamma.dims()[0], "RMSNorm forward")?;
+            }
+        }
+
+        let out = self.inner.forward(input.inner.clone());
+        Ok(WasmTensor { inner: out })
+    }
+}
+
 // ============================================================
 // FLOAT-BRIDGE + WEIGHT LAYOUT (M1b) — norm.
 // KONTRAK TRAINABLE-ONLY: hanya gamma (+ beta kalau ada) yang diekspos.
@@ -279,5 +366,49 @@ impl WasmNorm {
 
     pub fn weight_layout(&self) -> String {
         crate::layers::layout::segs_json(&self.weight_segs())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_group_config, validate_norm_axis, validate_rms_epsilon};
+
+    #[test]
+    fn group_config_rejects_zero_groups_before_modulo() {
+        assert!(validate_group_config(0, 8).is_err());
+    }
+
+    #[test]
+    fn group_config_rejects_non_divisible_channels() {
+        assert!(validate_group_config(3, 8).is_err());
+    }
+
+    #[test]
+    fn group_config_accepts_divisible_channels() {
+        assert!(validate_group_config(4, 8).is_ok());
+    }
+
+    #[test]
+    fn rms_epsilon_rejects_non_positive_and_nan() {
+        assert!(validate_rms_epsilon(0.0).is_err());
+        assert!(validate_rms_epsilon(-1e-5).is_err());
+        assert!(validate_rms_epsilon(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn rms_epsilon_accepts_positive_value() {
+        assert!(validate_rms_epsilon(1e-5).is_ok());
+    }
+
+    #[test]
+    fn norm_axis_rejects_feature_mismatch() {
+        let err = validate_norm_axis([2, 7, 4, 4], 1, 8, "GroupNorm forward").unwrap_err();
+        assert!(err.contains("size 8"));
+    }
+
+    #[test]
+    fn norm_axis_accepts_matching_feature_count() {
+        assert!(validate_norm_axis([2, 8, 4, 4], 1, 8, "GroupNorm forward").is_ok());
+        assert!(validate_norm_axis([2, 3, 4, 8], 3, 8, "RMSNorm forward").is_ok());
     }
 }

--- a/src/layers/pool.rs
+++ b/src/layers/pool.rs
@@ -11,6 +11,52 @@ use wasm_bindgen::prelude::*;
 use crate::WasmTensor;
 use crate::layers::shape_contract::require_singleton_axis;
 
+fn validate_pool1d_params(kernel_size: usize, stride: Option<usize>, context: &str) -> Result<(), String> {
+    if kernel_size == 0 {
+        return Err(format!("{context}: kernel_size must be greater than 0"));
+    }
+    if stride == Some(0) {
+        return Err(format!("{context}: stride must be greater than 0"));
+    }
+    Ok(())
+}
+
+fn validate_pool2d_params(
+    kernel_size_h: usize,
+    kernel_size_w: usize,
+    stride_h: Option<usize>,
+    stride_w: Option<usize>,
+    context: &str,
+) -> Result<(), String> {
+    if kernel_size_h == 0 || kernel_size_w == 0 {
+        return Err(format!(
+            "{context}: kernel sizes must be greater than 0, got [{kernel_size_h}, {kernel_size_w}]"
+        ));
+    }
+
+    // Preserve the existing wrapper contract: custom strides are applied only when both are Some.
+    if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
+        if sh == 0 || sw == 0 {
+            return Err(format!(
+                "{context}: strides must be greater than 0, got [{sh}, {sw}]"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn pool_fail<T>(message: String) -> T {
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen::throw_str(&message)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        panic!("{message}")
+    }
+}
+
 // --- CONFIGURATION ENUM ---
 #[derive(Debug)]
 pub enum PoolingConfig {
@@ -49,13 +95,9 @@ impl Pooling {
     // Input selalu 4D [Batch, Channel, H, W] dari WasmTensor
     pub fn forward<B: Backend>(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         match self {
-            // 2D pooling native support 4D
             Pooling::MaxPool2d(layer) => layer.forward(input),
             Pooling::AvgPool2d(layer) => layer.forward(input),
             Pooling::AdaptiveAvgPool2d(layer) => layer.forward(input),
-
-            // 1D pooling butuh 3D [Batch, Channel, Length]
-            // Squeeze dimensi terakhir (width), pool, lalu unsqueeze balik
             Pooling::MaxPool1d(layer) => {
                 let [b, c, h, _w] = input.dims();
                 let x_3d = input.reshape([b, c, h]);
@@ -88,19 +130,9 @@ impl WasmPool {
         stride: Option<usize>,
         padding: Option<usize>,
     ) -> WasmPool {
-        let mut config = MaxPool1dConfig::new(kernel_size);
-        if let Some(s) = stride {
-            config = config.with_stride(s);
-        }
-        if let Some(p) = padding {
-            config = config.with_padding(PaddingConfig1d::Explicit(p));
-        }
-        WasmPool {
-            inner: PoolingConfig::MaxPool1d(config).init(),
-        }
+        Self::try_new_max_pool1d(kernel_size, stride, padding).unwrap_or_else(pool_fail)
     }
 
-    // [usize; 2] dipecah jadi 2 parameter karena wasm_bindgen tidak support array
     #[wasm_bindgen(js_name = newMaxPool2d)]
     pub fn new_max_pool2d(
         kernel_size_h: usize,
@@ -110,16 +142,15 @@ impl WasmPool {
         padding_h: Option<usize>,
         padding_w: Option<usize>,
     ) -> WasmPool {
-        let mut config = MaxPool2dConfig::new([kernel_size_h, kernel_size_w]);
-        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
-            config = config.with_strides([sh, sw]);
-        }
-        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
-            config = config.with_padding(PaddingConfig2d::Explicit(ph, pw));
-        }
-        WasmPool {
-            inner: PoolingConfig::MaxPool2d(config).init(),
-        }
+        Self::try_new_max_pool2d(
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+        )
+        .unwrap_or_else(pool_fail)
     }
 
     #[wasm_bindgen(js_name = newAvgPool1d)]
@@ -128,16 +159,7 @@ impl WasmPool {
         stride: Option<usize>,
         padding: Option<usize>,
     ) -> WasmPool {
-        let mut config = AvgPool1dConfig::new(kernel_size);
-        if let Some(s) = stride {
-            config = config.with_stride(s);
-        }
-        if let Some(p) = padding {
-            config = config.with_padding(PaddingConfig1d::Explicit(p));
-        }
-        WasmPool {
-            inner: PoolingConfig::AvgPool1d(config).init(),
-        }
+        Self::try_new_avg_pool1d(kernel_size, stride, padding).unwrap_or_else(pool_fail)
     }
 
     #[wasm_bindgen(js_name = newAvgPool2d)]
@@ -149,16 +171,15 @@ impl WasmPool {
         padding_h: Option<usize>,
         padding_w: Option<usize>,
     ) -> WasmPool {
-        let mut config = AvgPool2dConfig::new([kernel_size_h, kernel_size_w]);
-        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
-            config = config.with_strides([sh, sw]);
-        }
-        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
-            config = config.with_padding(PaddingConfig2d::Explicit(ph, pw));
-        }
-        WasmPool {
-            inner: PoolingConfig::AvgPool2d(config).init(),
-        }
+        Self::try_new_avg_pool2d(
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+        )
+        .unwrap_or_else(pool_fail)
     }
 
     #[wasm_bindgen(js_name = newAdaptiveAvgPool2d)]
@@ -177,18 +198,149 @@ impl WasmPool {
             .unwrap_or_else(crate::layers::shape_contract::forward_fail)
     }
 
-    // Pooling tidak punya trainable params
     pub fn num_params(&self) -> usize {
         0
     }
 }
 
 impl WasmPool {
+    pub(crate) fn try_new_max_pool1d(
+        kernel_size: usize,
+        stride: Option<usize>,
+        padding: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_pool1d_params(kernel_size, stride, "MaxPool1d")?;
+        let mut config = MaxPool1dConfig::new(kernel_size);
+        if let Some(s) = stride {
+            config = config.with_stride(s);
+        }
+        if let Some(p) = padding {
+            config = config.with_padding(PaddingConfig1d::Explicit(p));
+        }
+        Ok(WasmPool {
+            inner: PoolingConfig::MaxPool1d(config).init(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_new_max_pool2d(
+        kernel_size_h: usize,
+        kernel_size_w: usize,
+        stride_h: Option<usize>,
+        stride_w: Option<usize>,
+        padding_h: Option<usize>,
+        padding_w: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_pool2d_params(
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            "MaxPool2d",
+        )?;
+        let mut config = MaxPool2dConfig::new([kernel_size_h, kernel_size_w]);
+        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
+            config = config.with_strides([sh, sw]);
+        }
+        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
+            config = config.with_padding(PaddingConfig2d::Explicit(ph, pw));
+        }
+        Ok(WasmPool {
+            inner: PoolingConfig::MaxPool2d(config).init(),
+        })
+    }
+
+    pub(crate) fn try_new_avg_pool1d(
+        kernel_size: usize,
+        stride: Option<usize>,
+        padding: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_pool1d_params(kernel_size, stride, "AvgPool1d")?;
+        let mut config = AvgPool1dConfig::new(kernel_size);
+        if let Some(s) = stride {
+            config = config.with_stride(s);
+        }
+        if let Some(p) = padding {
+            config = config.with_padding(PaddingConfig1d::Explicit(p));
+        }
+        Ok(WasmPool {
+            inner: PoolingConfig::AvgPool1d(config).init(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_new_avg_pool2d(
+        kernel_size_h: usize,
+        kernel_size_w: usize,
+        stride_h: Option<usize>,
+        stride_w: Option<usize>,
+        padding_h: Option<usize>,
+        padding_w: Option<usize>,
+    ) -> Result<Self, String> {
+        validate_pool2d_params(
+            kernel_size_h,
+            kernel_size_w,
+            stride_h,
+            stride_w,
+            "AvgPool2d",
+        )?;
+        let mut config = AvgPool2dConfig::new([kernel_size_h, kernel_size_w]);
+        if let (Some(sh), Some(sw)) = (stride_h, stride_w) {
+            config = config.with_strides([sh, sw]);
+        }
+        if let (Some(ph), Some(pw)) = (padding_h, padding_w) {
+            config = config.with_padding(PaddingConfig2d::Explicit(ph, pw));
+        }
+        Ok(WasmPool {
+            inner: PoolingConfig::AvgPool2d(config).init(),
+        })
+    }
+
     pub(crate) fn try_forward(&self, input: &WasmTensor) -> Result<WasmTensor, String> {
         if matches!(&self.inner, Pooling::MaxPool1d(_) | Pooling::AvgPool1d(_)) {
             require_singleton_axis(input.inner.dims(), 3, "Pool1d forward")?;
         }
         let out = self.inner.forward(input.inner.clone());
         Ok(WasmTensor { inner: out })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_pool1d_params, validate_pool2d_params};
+
+    #[test]
+    fn pool1d_rejects_zero_kernel() {
+        assert!(validate_pool1d_params(0, None, "pool").is_err());
+    }
+
+    #[test]
+    fn pool1d_rejects_zero_explicit_stride() {
+        assert!(validate_pool1d_params(3, Some(0), "pool").is_err());
+    }
+
+    #[test]
+    fn pool1d_accepts_positive_kernel_and_default_stride() {
+        assert!(validate_pool1d_params(3, None, "pool").is_ok());
+    }
+
+    #[test]
+    fn pool2d_rejects_zero_kernel_axis() {
+        assert!(validate_pool2d_params(3, 0, None, None, "pool").is_err());
+    }
+
+    #[test]
+    fn pool2d_rejects_zero_paired_stride_axis() {
+        assert!(validate_pool2d_params(3, 3, Some(1), Some(0), "pool").is_err());
+    }
+
+    #[test]
+    fn pool2d_preserves_partial_stride_behavior() {
+        assert!(validate_pool2d_params(3, 3, Some(0), None, "pool").is_ok());
+    }
+
+    #[test]
+    fn pool2d_accepts_positive_parameters() {
+        assert!(validate_pool2d_params(3, 5, Some(2), Some(1), "pool").is_ok());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod layers;
 pub mod protocol;
 pub mod registry;
 #[cfg(test)]
+mod stateless_lifecycle_tests;
+#[cfg(test)]
 mod tests;
 
 pub type WasmBackend = burn_ndarray::NdArray<f32>;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -124,21 +124,21 @@ impl LayerRegistry {
                 .get(&layer_id)
                 .ok_or_else(|| "Linear not found".to_string())?
                 .try_forward(input),
-            LAYER_NORM => Ok(self
+            LAYER_NORM => self
                 .norms
                 .get(&layer_id)
                 .ok_or_else(|| "Norm not found".to_string())?
-                .forward(input)),
+                .try_forward(input),
             LAYER_CONV => self
                 .convs
                 .get(&layer_id)
                 .ok_or_else(|| "Conv not found".to_string())?
                 .try_forward(input),
-            LAYER_ACTIVATION => Ok(self
+            LAYER_ACTIVATION => self
                 .activations
                 .get(&layer_id)
                 .ok_or_else(|| "Activation not found".to_string())?
-                .forward(input)),
+                .try_forward(input),
             LAYER_EMBEDDING => self
                 .embeddings
                 .get(&layer_id)
@@ -178,7 +178,13 @@ impl LayerRegistry {
             LAYER_EMBEDDING   => self.embeddings.get(&layer_id).ok_or("Not found")?.get_state(),
             LAYER_GHOST       => self.ghosts.get(&layer_id).ok_or("Not found")?.get_state(),
             LAYER_SEBLOCK     => self.seblocks.get(&layer_id).ok_or("Not found")?.get_state(),
-            LAYER_POOL | LAYER_SHIFT | LAYER_BINARY => Ok(vec![]),
+            LAYER_POOL | LAYER_SHIFT | LAYER_BINARY => {
+                if self.layer_exists(layer_type, layer_id) {
+                    Ok(vec![])
+                } else {
+                    Err("Not found".into())
+                }
+            }
             _ => Err(format!("Unknown layer type for get_state: 0x{:02X}", layer_type)),
         }
     }
@@ -193,7 +199,13 @@ impl LayerRegistry {
             LAYER_EMBEDDING   => load_layer_state!(self, embeddings, layer_id, data),
             LAYER_GHOST       => load_layer_state!(self, ghosts, layer_id, data),
             LAYER_SEBLOCK     => load_layer_state!(self, seblocks, layer_id, data),
-            LAYER_POOL | LAYER_SHIFT | LAYER_BINARY => Ok(()),
+            LAYER_POOL | LAYER_SHIFT | LAYER_BINARY => {
+                if self.layer_exists(layer_type, layer_id) {
+                    Ok(())
+                } else {
+                    Err("Not found".into())
+                }
+            }
             _ => Err(format!("Unknown layer type for load_state: 0x{:02X}", layer_type)),
         }
     }
@@ -241,11 +253,11 @@ impl LayerRegistry {
             NORM_GROUP     => {
                 let num_groups = c.read_usize()?;
                 let num_channels = c.read_usize()?;
-                WasmNorm::new_group_norm(num_groups, num_channels, eps)
+                WasmNorm::try_new_group_norm(num_groups, num_channels, eps)?
             }
             NORM_INSTANCE  => WasmNorm::new_instance_norm(size, eps),
             NORM_LAYER     => WasmNorm::new_layer_norm(size, eps),
-            NORM_RMS       => WasmNorm::new_rms_norm(size, eps),
+            NORM_RMS       => WasmNorm::try_new_rms_norm(size, eps)?,
             _ => return Err(format!("Unknown norm variant: 0x{:02X}", header.variant)),
         };
         insert_layer!(self, norms, id, layer);
@@ -264,9 +276,9 @@ impl LayerRegistry {
         let ph = c.read_option_usize()?;
         let pw = c.read_option_usize()?;
         let layer = match header.variant {
-            CONV_CONV1D          => WasmConv::new_conv1d(in_ch, out_ch, kh, sh, ph),
-            CONV_CONV2D          => WasmConv::new_conv2d(in_ch, out_ch, kh, kw, sh, sw, ph, pw),
-            CONV_CONVTRANSPOSE2D => WasmConv::new_conv_transpose2d(in_ch, out_ch, kh, kw, sh, sw, ph, pw),
+            CONV_CONV1D          => WasmConv::try_new_conv1d(in_ch, out_ch, kh, sh, ph)?,
+            CONV_CONV2D          => WasmConv::try_new_conv2d(in_ch, out_ch, kh, kw, sh, sw, ph, pw)?,
+            CONV_CONVTRANSPOSE2D => WasmConv::try_new_conv_transpose2d(in_ch, out_ch, kh, kw, sh, sw, ph, pw)?,
             _ => return Err(format!("Unknown conv variant: 0x{:02X}", header.variant)),
         };
         insert_layer!(self, convs, id, layer);
@@ -343,13 +355,13 @@ impl LayerRegistry {
                 let k = c.read_usize()?;
                 let s = c.read_option_usize()?;
                 let p = c.read_option_usize()?;
-                WasmPool::new_max_pool1d(k, s, p)
+                WasmPool::try_new_max_pool1d(k, s, p)?
             }
             POOL_AVGPOOL1D => {
                 let k = c.read_usize()?;
                 let s = c.read_option_usize()?;
                 let p = c.read_option_usize()?;
-                WasmPool::new_avg_pool1d(k, s, p)
+                WasmPool::try_new_avg_pool1d(k, s, p)?
             }
             POOL_MAXPOOL2D => {
                 let k = c.read_usize()?;
@@ -358,7 +370,7 @@ impl LayerRegistry {
                 let sw = c.read_option_usize()?;
                 let ph = c.read_option_usize()?;
                 let pw = c.read_option_usize()?;
-                WasmPool::new_max_pool2d(k, kw, sh, sw, ph, pw)
+                WasmPool::try_new_max_pool2d(k, kw, sh, sw, ph, pw)?
             }
             POOL_AVGPOOL2D => {
                 let k = c.read_usize()?;
@@ -367,7 +379,7 @@ impl LayerRegistry {
                 let sw = c.read_option_usize()?;
                 let ph = c.read_option_usize()?;
                 let pw = c.read_option_usize()?;
-                WasmPool::new_avg_pool2d(k, kw, sh, sw, ph, pw)
+                WasmPool::try_new_avg_pool2d(k, kw, sh, sw, ph, pw)?
             }
             POOL_ADAPTIVEAVGPOOL2D => {
                 let oh = c.read_usize()?;

--- a/src/stateless_lifecycle_tests.rs
+++ b/src/stateless_lifecycle_tests.rs
@@ -1,0 +1,86 @@
+#[cfg(test)]
+mod tests {
+    use crate::protocol::{
+        PacketHeader, BINARY_ADD, LAYER_BINARY, LAYER_POOL, LAYER_SHIFT, OP_INIT,
+        POOL_MAXPOOL1D, SHIFT_UP,
+    };
+    use crate::registry::LayerRegistry;
+
+    fn header(layer_type: u8, variant: u8, payload_len: usize) -> PacketHeader {
+        let mut bytes = [0u8; 8];
+        bytes[0] = OP_INIT;
+        bytes[1] = layer_type;
+        bytes[2] = variant;
+        bytes[4..8].copy_from_slice(&(payload_len as u32).to_le_bytes());
+        PacketHeader::from_bytes(&bytes).unwrap()
+    }
+
+    fn assert_missing_state(reg: &mut LayerRegistry, id: u32, layer_type: u8) {
+        assert!(reg.get_layer_state(id, layer_type).is_err());
+        assert!(reg.load_layer_state(id, layer_type, &[9, 8, 7]).is_err());
+    }
+
+    fn assert_present_stateless_state(reg: &mut LayerRegistry, id: u32, layer_type: u8) {
+        assert_eq!(reg.get_layer_state(id, layer_type).unwrap(), Vec::<u8>::new());
+        // Preserve the existing stateless contract: state bytes are ignored.
+        assert!(reg.load_layer_state(id, layer_type, &[9, 8, 7]).is_ok());
+    }
+
+    #[test]
+    fn pool_state_api_tracks_pool_lifecycle() {
+        let id = 41u32;
+        let mut reg = LayerRegistry::new();
+        assert_missing_state(&mut reg, id, LAYER_POOL);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&id.to_le_bytes());
+        payload.extend_from_slice(&2u32.to_le_bytes()); // kernel
+        payload.push(0); // stride None, fixed-width option
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        payload.push(0); // padding None, fixed-width option
+        payload.extend_from_slice(&0u32.to_le_bytes());
+        reg.init_layer(&header(LAYER_POOL, POOL_MAXPOOL1D, payload.len()), &payload)
+            .unwrap();
+
+        assert!(reg.layer_exists(LAYER_POOL, id));
+        assert_present_stateless_state(&mut reg, id, LAYER_POOL);
+        assert!(reg.destroy_layer(id, LAYER_POOL));
+        assert_missing_state(&mut reg, id, LAYER_POOL);
+    }
+
+    #[test]
+    fn shift_state_api_tracks_shift_lifecycle() {
+        let id = 42u32;
+        let mut reg = LayerRegistry::new();
+        assert_missing_state(&mut reg, id, LAYER_SHIFT);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&id.to_le_bytes());
+        payload.extend_from_slice(&1u32.to_le_bytes());
+        reg.init_layer(&header(LAYER_SHIFT, SHIFT_UP, payload.len()), &payload)
+            .unwrap();
+
+        assert!(reg.layer_exists(LAYER_SHIFT, id));
+        assert_present_stateless_state(&mut reg, id, LAYER_SHIFT);
+        assert!(reg.destroy_layer(id, LAYER_SHIFT));
+        assert_missing_state(&mut reg, id, LAYER_SHIFT);
+    }
+
+    #[test]
+    fn binary_state_api_tracks_binary_lifecycle() {
+        let id = 43u32;
+        let mut reg = LayerRegistry::new();
+        assert_missing_state(&mut reg, id, LAYER_BINARY);
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&id.to_le_bytes());
+        payload.extend_from_slice(&0u32.to_le_bytes()); // concat dim unused by ADD
+        reg.init_layer(&header(LAYER_BINARY, BINARY_ADD, payload.len()), &payload)
+            .unwrap();
+
+        assert!(reg.layer_exists(LAYER_BINARY, id));
+        assert_present_stateless_state(&mut reg, id, LAYER_BINARY);
+        assert!(reg.destroy_layer(id, LAYER_BINARY));
+        assert_missing_state(&mut reg, id, LAYER_BINARY);
+    }
+}


### PR DESCRIPTION
## Tujuan
Mengonsolidasikan PR hardening yang sekarang konflik karena semuanya berangkat dari baseline lama, tanpa kehilangan invariant yang sudah dibuktikan masing-masing PR.

## Mengintegrasikan
- #19 stateless lifecycle state API
- #22 activation axis/GLU forward contracts
- #23 normalization config + forward contracts
- #24 pooling parameter contracts
- #25 convolution stride contracts

## Basis
Dibangun di atas `main` setelah #21 sudah merged. Shape guards #21 dipertahankan dan digabung dengan constructor/parameter guards #24/#25.

## Invariant gabungan
- Linear/Conv/Embedding/Pool shape guards #21 tetap aktif
- Activation dan Norm malformed forward mengembalikan error melalui registry sebelum backend panic
- GroupNorm/RMSNorm malformed config ditolak sebelum init backend
- Conv/Pool zero effective stride/kernel ditolak sebelum Burn config init
- Stateless Pool/Shift/Binary get/load state mengikuti lifecycle existence
- Direct WASM constructors/forward tetap mempertahankan controlled boundary behavior
- Graph dan float/weight bridge tidak diubah selain memakai registry boundary yang sudah diperketat

## Validasi
Semua sumber perubahan asal sebelumnya sudah CI hijau secara independen. PR integrasi ini wajib melewati host check, clippy, WASM check/build, dan host tests sebagai bukti komposisi sebelum merge.