### PR TITLE
Clean up low-risk Clippy warnings

### DIFF
--- a/src/es/optimizer.rs
+++ b/src/es/optimizer.rs
@@ -110,7 +110,10 @@ impl EsOptimizer {
         let (mean, std) = mean_std(&f64s);
         let mut best = f64::NEG_INFINITY;
         let mut worst = f64::INFINITY;
-        for &v in &f64s { if v > best { best = v; } if v < worst { worst = v; } }
+        for &v in &f64s {
+            if v > best { best = v; }
+            if v < worst { worst = v; }
+        }
 
         // global best + stagnation (scan kandidat vs fitness)
         let mut gen_best = f64::NEG_INFINITY;

--- a/src/layers/activation.rs
+++ b/src/layers/activation.rs
@@ -18,7 +18,7 @@ fn validate_rank4_axis(dim: usize, context: &str) -> Result<(), String> {
 fn validate_glu_shape(shape: [usize; 4], dim: usize) -> Result<(), String> {
     validate_rank4_axis(dim, "GLU forward")?;
     let n = shape[dim];
-    if n % 2 != 0 {
+    if !n.is_multiple_of(2) {
         return Err(format!(
             "GLU forward: axis {dim} size must be divisible by 2, got {n} for shape {:?}",
             shape

--- a/src/layers/custom/ghost.rs
+++ b/src/layers/custom/ghost.rs
@@ -41,16 +41,16 @@ impl GhostModuleConfig {
         if self.out_channels == 0 {
             return Err("ghost: out_channels must be > 0".into());
         }
-        if self.kernel_size.iter().any(|&v| v == 0) {
+        if self.kernel_size.contains(&0) {
             return Err("ghost: kernel dimensions must be > 0".into());
         }
-        if self.stride.iter().any(|&v| v == 0) {
+        if self.stride.contains(&0) {
             return Err("ghost: stride dimensions must be > 0".into());
         }
         if self.ratio == 0 {
             return Err("ghost: ratio must be > 0".into());
         }
-        if self.out_channels % self.ratio != 0 {
+        if !self.out_channels.is_multiple_of(self.ratio) {
             return Err(format!(
                 "ghost: out_channels ({}) must be divisible by ratio ({})",
                 self.out_channels, self.ratio


### PR DESCRIPTION
## Tujuan
Mengurangi warning Clippy yang aman/mechanical tanpa mengubah semantics numerik, public API, layout, atau proof boundary.

## Perubahan
- pisahkan dua `if` independen pada scan best/worst ES agar tidak terkena `possible_missing_else`
- gunakan `usize::is_multiple_of` untuk validasi GLU dengan semantics divisibility yang sama
- gunakan `contains(&0)` dan `is_multiple_of` pada Ghost config validation

## Yang sengaja tidak disentuh
- `large_enum_variant`
- `too_many_arguments`
- `type_complexity`
- epsilon/NaN comparison semantics
- ES strategy iterator refactor
- public WASM API/layout

## Invariant
- valid-input behavior harus identik
- invalid-input behavior harus identik
- existing regression tests menjadi proof gate
- setelah CI hijau, artifact workflow akan dites langsung pada runtime WASM.