### PR TITLE
Experiment with stateless workspace orchestration

### DIFF
--- a/docs/workspace-stateless-ops.md
+++ b/docs/workspace-stateless-ops.md
@@ -1,0 +1,50 @@
+# Stateless Workspace Orchestration Experiment
+
+This experiment keeps `AgentWorkspace` as the only convenience-state owner.
+
+The exported helpers are free functions:
+
+- `workspaceWireUnary(...)`
+- `workspaceWireBinary(...)`
+- `workspaceInitUnary(...)`
+- `workspaceInitBinary(...)`
+- `workspaceCompile(...)`
+
+They do not allocate or retain any hidden session state.
+
+## Intended flow
+
+```text
+AgentWorkspace.reserveLayerId(registry, label)
+        |
+        v
+AgentLayerSpec::<constructor>(reserved_id)
+        |
+        v
+workspaceInitUnary / workspaceInitBinary
+        |
+        +--> AgentWorkspace.reserveSlot(...)
+        +--> LayerRegistry.initAgentLayer(...)
+        +--> AgentWorkspace.syncLayer(...)
+        +--> AgentGraphBuilder.addUnary/addBinary(...)
+```
+
+`workspaceInit*` requires the layer id to have been reserved through the same workspace first. This keeps allocator truth in one place and prevents helper-local state from drifting away from workspace metadata.
+
+For layers initialized manually through lower-level APIs, `workspaceWire*` reconciles the real registry into workspace metadata before adding graph wiring.
+
+## Flexibility
+
+The helper layer is optional. Callers can freely mix:
+
+```text
+workspace helper -> typed API -> raw registry/graph API -> workspace helper
+```
+
+There is no helper object to synchronize or preserve.
+
+## Failure boundary
+
+Expected validation happens before registry mutation where possible. Output slots reserved by the workspace are released again when a pre-registry or graph-wiring failure is recoverable.
+
+The existing `AgentReferenceSession` remains unchanged for compatibility/comparison. This experiment does not remove it or make it the source of truth.

--- a/docs/workspace-stateless-ops.md
+++ b/docs/workspace-stateless-ops.md
@@ -41,7 +41,7 @@ The helper layer is optional. Callers can freely mix:
 workspace helper -> typed API -> raw registry/graph API -> workspace helper
 ```
 
-There is no helper object to synchronize or preserve.
+There is no helper object to synchronize or preserve. Runtime proof should therefore succeed without constructing `AgentReferenceSession` at all.
 
 ## Failure boundary
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,6 +7,7 @@ use crate::protocol::{
     LAYER_NORM, LAYER_POOL, LAYER_SEBLOCK, LAYER_SHIFT,
 };
 use crate::registry::LayerRegistry;
+use crate::workspace::AgentWorkspace;
 
 const KNOWN_LAYER_TYPES: [u8; 10] = [
     LAYER_LINEAR,
@@ -20,6 +21,8 @@ const KNOWN_LAYER_TYPES: [u8; 10] = [
     LAYER_SEBLOCK,
     LAYER_BINARY,
 ];
+
+const MAX_WORKSPACE_OP_LABEL_BYTES: usize = 4000;
 
 #[wasm_bindgen]
 pub struct AgentReferenceSession {
@@ -89,6 +92,206 @@ impl AgentReferenceSession {
         }
         Ok(())
     }
+}
+
+fn validate_workspace_op_label(label: &str, context: &str) -> Result<(), String> {
+    if label.len() > MAX_WORKSPACE_OP_LABEL_BYTES {
+        return Err(format!(
+            "{context}: label {} bytes exceeds helper limit {MAX_WORKSPACE_OP_LABEL_BYTES}",
+            label.len()
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_workspace_layer_reserved(
+    workspace: &AgentWorkspace,
+    spec: &AgentLayerSpec,
+    context: &str,
+) -> Result<(), String> {
+    let row = workspace.get("_layers".into(), spec.layer_id().to_string());
+    if row == "null" || !row.contains("\"state\":\"reserved\"") {
+        return Err(format!(
+            "{context}: layer id {} must be reserved through AgentWorkspace.reserveLayerId before initialization",
+            spec.layer_id()
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_registry_has_spec(
+    registry: &LayerRegistry,
+    spec: &AgentLayerSpec,
+    context: &str,
+) -> Result<(), String> {
+    if !registry.layer_exists(spec.layer_type(), spec.layer_id()) {
+        return Err(format!(
+            "{context}: layer type 0x{:02X} id {} is not initialized in registry",
+            spec.layer_type(),
+            spec.layer_id()
+        ));
+    }
+    Ok(())
+}
+
+fn reserve_workspace_output_slot(
+    workspace: &mut AgentWorkspace,
+    builder: &AgentGraphBuilder,
+    owner: String,
+    context: &str,
+) -> Result<u8, String> {
+    let slot = workspace.reserve_slot(owner)?;
+    if let Err(err) = AgentReferenceSession::validate_input_slot(builder, slot, context) {
+        let _ = workspace.release_slot(slot);
+        return Err(err);
+    }
+    Ok(slot)
+}
+
+/// Stateless convenience path: all allocator/state truth remains in AgentWorkspace.
+#[wasm_bindgen(js_name = workspaceWireUnary)]
+pub fn workspace_wire_unary(
+    workspace: &mut AgentWorkspace,
+    builder: &mut AgentGraphBuilder,
+    registry: &LayerRegistry,
+    spec: &AgentLayerSpec,
+    input_slot: u8,
+    label: String,
+) -> Result<u8, String> {
+    if spec.layer_type() == LAYER_BINARY {
+        return Err("workspaceWireUnary: binary spec requires workspaceWireBinary".into());
+    }
+    AgentReferenceSession::validate_input_slot(builder, input_slot, "workspaceWireUnary")?;
+    ensure_registry_has_spec(registry, spec, "workspaceWireUnary")?;
+    validate_workspace_op_label(&label, "workspaceWireUnary")?;
+
+    // Reconcile metadata first. If quota/metadata validation fails, graph state is untouched.
+    workspace.sync_layer(registry, spec, label)?;
+    let output_slot = reserve_workspace_output_slot(
+        workspace,
+        builder,
+        format!("layer:{}", spec.layer_id()),
+        "workspaceWireUnary",
+    )?;
+    if let Err(err) = builder.add_unary(spec, input_slot, output_slot) {
+        let _ = workspace.release_slot(output_slot);
+        return Err(err);
+    }
+    Ok(output_slot)
+}
+
+#[wasm_bindgen(js_name = workspaceWireBinary)]
+pub fn workspace_wire_binary(
+    workspace: &mut AgentWorkspace,
+    builder: &mut AgentGraphBuilder,
+    registry: &LayerRegistry,
+    spec: &AgentLayerSpec,
+    left_slot: u8,
+    right_slot: u8,
+    label: String,
+) -> Result<u8, String> {
+    if spec.layer_type() != LAYER_BINARY {
+        return Err("workspaceWireBinary: spec is not binary".into());
+    }
+    AgentReferenceSession::validate_input_slot(builder, left_slot, "workspaceWireBinary")?;
+    AgentReferenceSession::validate_input_slot(builder, right_slot, "workspaceWireBinary")?;
+    ensure_registry_has_spec(registry, spec, "workspaceWireBinary")?;
+    validate_workspace_op_label(&label, "workspaceWireBinary")?;
+
+    workspace.sync_layer(registry, spec, label)?;
+    let output_slot = reserve_workspace_output_slot(
+        workspace,
+        builder,
+        format!("layer:{}", spec.layer_id()),
+        "workspaceWireBinary",
+    )?;
+    if let Err(err) = builder.add_binary(spec, left_slot, right_slot, output_slot) {
+        let _ = workspace.release_slot(output_slot);
+        return Err(err);
+    }
+    Ok(output_slot)
+}
+
+#[wasm_bindgen(js_name = workspaceInitUnary)]
+pub fn workspace_init_unary(
+    workspace: &mut AgentWorkspace,
+    builder: &mut AgentGraphBuilder,
+    registry: &mut LayerRegistry,
+    spec: &AgentLayerSpec,
+    input_slot: u8,
+    label: String,
+) -> Result<u8, String> {
+    if spec.layer_type() == LAYER_BINARY {
+        return Err("workspaceInitUnary: binary spec requires workspaceInitBinary".into());
+    }
+    AgentReferenceSession::validate_input_slot(builder, input_slot, "workspaceInitUnary")?;
+    AgentReferenceSession::validate_spec_is_new(registry, spec)?;
+    ensure_workspace_layer_reserved(workspace, spec, "workspaceInitUnary")?;
+    validate_workspace_op_label(&label, "workspaceInitUnary")?;
+
+    let output_slot = reserve_workspace_output_slot(
+        workspace,
+        builder,
+        format!("layer:{}", spec.layer_id()),
+        "workspaceInitUnary",
+    )?;
+
+    if let Err(err) = registry.init_agent_layer(spec) {
+        let _ = workspace.release_slot(output_slot);
+        return Err(err);
+    }
+
+    // The reserved _layers row already exists, so this is an in-place metadata transition.
+    workspace.sync_layer(registry, spec, label)?;
+    builder.add_unary(spec, input_slot, output_slot)?;
+    Ok(output_slot)
+}
+
+#[wasm_bindgen(js_name = workspaceInitBinary)]
+pub fn workspace_init_binary(
+    workspace: &mut AgentWorkspace,
+    builder: &mut AgentGraphBuilder,
+    registry: &mut LayerRegistry,
+    spec: &AgentLayerSpec,
+    left_slot: u8,
+    right_slot: u8,
+    label: String,
+) -> Result<u8, String> {
+    if spec.layer_type() != LAYER_BINARY {
+        return Err("workspaceInitBinary: spec is not binary".into());
+    }
+    AgentReferenceSession::validate_input_slot(builder, left_slot, "workspaceInitBinary")?;
+    AgentReferenceSession::validate_input_slot(builder, right_slot, "workspaceInitBinary")?;
+    AgentReferenceSession::validate_spec_is_new(registry, spec)?;
+    ensure_workspace_layer_reserved(workspace, spec, "workspaceInitBinary")?;
+    validate_workspace_op_label(&label, "workspaceInitBinary")?;
+
+    let output_slot = reserve_workspace_output_slot(
+        workspace,
+        builder,
+        format!("layer:{}", spec.layer_id()),
+        "workspaceInitBinary",
+    )?;
+
+    if let Err(err) = registry.init_agent_layer(spec) {
+        let _ = workspace.release_slot(output_slot);
+        return Err(err);
+    }
+
+    workspace.sync_layer(registry, spec, label)?;
+    builder.add_binary(spec, left_slot, right_slot, output_slot)?;
+    Ok(output_slot)
+}
+
+#[wasm_bindgen(js_name = workspaceCompile)]
+pub fn workspace_compile(
+    builder: &mut AgentGraphBuilder,
+    registry: &LayerRegistry,
+    output_slot: u8,
+) -> Result<CompiledGraph, String> {
+    AgentReferenceSession::validate_input_slot(builder, output_slot, "workspaceCompile")?;
+    builder.set_output(output_slot)?;
+    builder.compile(registry)
 }
 
 #[wasm_bindgen]
@@ -249,10 +452,14 @@ impl AgentReferenceSession {
 
 #[cfg(test)]
 mod tests {
-    use super::AgentReferenceSession;
+    use super::{
+        workspace_compile, workspace_init_binary, workspace_init_unary, workspace_wire_unary,
+        AgentReferenceSession,
+    };
     use crate::agent::{AgentGraphBuilder, AgentLayerSpec};
     use crate::protocol::{LAYER_ACTIVATION, LAYER_BINARY};
     use crate::registry::LayerRegistry;
+    use crate::workspace::AgentWorkspace;
     use crate::WasmTensor;
 
     #[test]
@@ -335,5 +542,107 @@ mod tests {
         assert_eq!(session.reserve_slot().unwrap(), 5);
         session.set_next_layer_id(900);
         assert_eq!(session.next_layer_id(), 900);
+    }
+
+    #[test]
+    fn workspace_helpers_keep_all_state_in_workspace() {
+        let mut workspace = AgentWorkspace::new(5).unwrap();
+        let mut registry = LayerRegistry::new();
+        let mut builder = AgentGraphBuilder::new(5).unwrap();
+
+        let relu_id = workspace.reserve_layer_id(&registry, "relu".into()).unwrap();
+        let relu = AgentLayerSpec::relu(relu_id);
+        let relu_slot = workspace_init_unary(
+            &mut workspace,
+            &mut builder,
+            &mut registry,
+            &relu,
+            0,
+            "relu".into(),
+        )
+        .unwrap();
+
+        let add_id = workspace.reserve_layer_id(&registry, "add".into()).unwrap();
+        let add = AgentLayerSpec::add(add_id);
+        let sum_slot = workspace_init_binary(
+            &mut workspace,
+            &mut builder,
+            &mut registry,
+            &add,
+            relu_slot,
+            relu_slot,
+            "add".into(),
+        )
+        .unwrap();
+
+        let graph = workspace_compile(&mut builder, &registry, sum_slot).unwrap();
+        let input = WasmTensor::new(&[-2.0, 3.0], &[1, 2, 1, 1]);
+        assert_eq!(graph.run(&registry, &input).unwrap().to_array(), vec![0.0, 6.0]);
+        assert!(workspace.get("_layers".into(), relu_id.to_string()).contains("initialized"));
+        assert!(workspace.get("_slots".into(), sum_slot.to_string()).contains("reserved"));
+    }
+
+    #[test]
+    fn workspace_init_requires_workspace_reserved_layer_id() {
+        let mut workspace = AgentWorkspace::new(3).unwrap();
+        let mut registry = LayerRegistry::new();
+        let mut builder = AgentGraphBuilder::new(3).unwrap();
+        let relu = AgentLayerSpec::relu(77);
+
+        assert!(workspace_init_unary(
+            &mut workspace,
+            &mut builder,
+            &mut registry,
+            &relu,
+            0,
+            "relu".into(),
+        )
+        .is_err());
+        assert!(!registry.layer_exists(LAYER_ACTIVATION, 77));
+        assert!(workspace.get("_slots".into(), "1".into()).contains("free"));
+    }
+
+    #[test]
+    fn workspace_failed_arity_does_not_consume_slot_or_initialize_layer() {
+        let mut workspace = AgentWorkspace::new(3).unwrap();
+        let mut registry = LayerRegistry::new();
+        let mut builder = AgentGraphBuilder::new(3).unwrap();
+        let add_id = workspace.reserve_layer_id(&registry, "add".into()).unwrap();
+        let add = AgentLayerSpec::add(add_id);
+
+        assert!(workspace_init_unary(
+            &mut workspace,
+            &mut builder,
+            &mut registry,
+            &add,
+            0,
+            "add".into(),
+        )
+        .is_err());
+        assert!(!registry.layer_exists(LAYER_BINARY, add_id));
+        assert!(workspace.get("_slots".into(), "1".into()).contains("free"));
+    }
+
+    #[test]
+    fn workspace_wire_manual_layer_reconciles_without_new_helper_state() {
+        let mut workspace = AgentWorkspace::new(3).unwrap();
+        let mut registry = LayerRegistry::new();
+        let mut builder = AgentGraphBuilder::new(3).unwrap();
+        let relu = AgentLayerSpec::relu(42);
+        registry.init_agent_layer(&relu).unwrap();
+
+        let out = workspace_wire_unary(
+            &mut workspace,
+            &mut builder,
+            &registry,
+            &relu,
+            0,
+            "manual-relu".into(),
+        )
+        .unwrap();
+        let graph = workspace_compile(&mut builder, &registry, out).unwrap();
+        let input = WasmTensor::new(&[-1.0, 4.0], &[1, 2, 1, 1]);
+        assert_eq!(graph.run(&registry, &input).unwrap().to_array(), vec![0.0, 4.0]);
+        assert!(workspace.get("_layers".into(), "42".into()).contains("manual-relu"));
     }
 }


### PR DESCRIPTION
## Tujuan
Menguji convenience orchestration yang benar-benar stateless di atas `AgentWorkspace`, tanpa allocator atau lifecycle state tersembunyi di helper.

## Stacked base
PR eksperimen ini ditumpuk di atas PR #35 (`experiment/agent-workspace-memory`). Tidak dimaksudkan untuk merge ke main sebelum hasil perbandingan arsitektur dinilai.

## API stateless
- `workspaceWireUnary(...)`
- `workspaceWireBinary(...)`
- `workspaceInitUnary(...)`
- `workspaceInitBinary(...)`
- `workspaceCompile(...)`

## Prinsip
- semua slot/layer allocation tetap milik `AgentWorkspace`
- `workspaceInit*` mewajibkan layer id sudah di-reserve melalui workspace yang sama
- helper tidak menyimpan `next_slot`, `next_layer_id`, registry, builder, tensor, atau graph
- lower-level typed/raw APIs tetap dapat dipakai di tengah workflow
- manual layer dapat direkonsiliasi lewat `workspaceWire*`
- `AgentReferenceSession` lama tidak dihapus; tetap ada untuk compatibility/comparison

## Invariant
- wrong arity/invalid input tidak mengonsumsi workspace slot
- unreserved layer id tidak menginisialisasi registry
- recoverable output-slot failure me-release reservation
- workspace tetap menjadi control-plane truth, registry tetap execution truth
- helper dapat hilang sepenuhnya karena tidak ada object/state yang perlu dipertahankan

## Proof gate
- host check, Clippy, wasm32 check, wasm-pack build, host tests
- runtime artifact: workspace-only state flow, manual+helper mixing, failure recovery, graph run, existing verifier, and no helper object/state dependency