### PR TITLE
Audit Burn NdArray execution contract baseline

### DIFF
--- a/docs/burn-contract-baseline.md
+++ b/docs/burn-contract-baseline.md
@@ -1,0 +1,42 @@
+# Burn Contract Baseline
+
+This document records the Burn semantics that the agent workflow is allowed to rely on today.
+
+## Current execution profile
+
+- Burn is the numerical/module execution layer. Workspace, Registry, and AgentGraphBuilder orchestrate Burn; they do not replace Burn tensor or module semantics.
+- `WasmBackend` is `burn_ndarray::NdArray<f32>`.
+- The current backend is intentionally non-autodiff. Autodiff is deferred by architecture and is not a missing baseline requirement.
+- The WASM bridge normalizes external tensors to rank 4. Individual wrappers may reshape to the rank expected by the underlying Burn module and must validate the adapter boundary first.
+- Modules are created using Burn configs on the backend default device and executed through the real Burn `forward` implementations.
+- Module records remain the serialization/state boundary used by Registry state APIs and gradient-free weight bridges.
+
+## BatchNorm consequence
+
+Burn BatchNorm selects training or inference behavior from the backend AD state. With the current non-AD NdArray backend, BatchNorm uses inference behavior and does not update `running_mean` / `running_var` during `forward`.
+
+This is a deliberate baseline property. Regression tests serialize BatchNorm state before and after forward calls and require byte-for-byte equality.
+
+If an autodiff backend is introduced later, this assumption becomes invalid by design: BatchNorm may update running state during training forwards. That future change must introduce an explicit execution-state contract and new failure/recovery audit before the backend can be promoted.
+
+## Contract boundaries
+
+The following are accepted adapter constraints rather than Burn constraints:
+
+- rank-4 `WasmTensor` bridge;
+- graph slots and `CompiledGraph` execution order;
+- Workspace lifecycle and transactional initialization;
+- init identity fingerprints and proof metadata.
+
+The following remain Burn-owned semantics and must not be silently redefined by the wrapper:
+
+- backend/device behavior;
+- tensor dtype/rank requirements of each Burn operation;
+- module parameter and record semantics;
+- forward numerical behavior;
+- autodiff behavior when/if an AD backend is enabled;
+- running-state behavior of stateful modules.
+
+## Promotion rule
+
+A backend or training-mode change is not a transparent implementation detail. Any change that alters `Backend::ad_enabled`, device semantics, dtype behavior, or stateful-module forward behavior requires a Burn contract-conformance audit before it becomes the default agent execution profile.

--- a/tests/burn_contract_baseline.rs
+++ b/tests/burn_contract_baseline.rs
@@ -1,0 +1,51 @@
+use burn::tensor::backend::Backend;
+use burn_research::agent::AgentLayerSpec;
+use burn_research::protocol::LAYER_NORM;
+use burn_research::registry::LayerRegistry;
+use burn_research::{WasmBackend, WasmTensor};
+
+#[test]
+fn ndarray_backend_is_explicitly_non_autodiff() {
+    let device = <WasmBackend as Backend>::Device::default();
+    assert!(
+        !<WasmBackend as Backend>::ad_enabled(&device),
+        "NdArray baseline must remain non-autodiff; enabling AD changes Burn module semantics and requires a contract audit"
+    );
+}
+
+#[test]
+fn batch_norm_forward_keeps_running_state_unchanged_on_ndarray_baseline() {
+    let mut registry = LayerRegistry::new();
+    let spec = AgentLayerSpec::batch_norm(7, 2, None).unwrap();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let state_before = registry.get_layer_state(7, LAYER_NORM).unwrap();
+    let input = WasmTensor::new(&[1.0, 2.0, 3.0, 4.0], &[2, 2, 1, 1]);
+
+    registry.forward_layer(7, LAYER_NORM, &input).unwrap();
+    registry.forward_layer(7, LAYER_NORM, &input).unwrap();
+
+    let state_after = registry.get_layer_state(7, LAYER_NORM).unwrap();
+    assert_eq!(
+        state_after, state_before,
+        "Burn BatchNorm must stay on inference semantics for the non-AD NdArray baseline"
+    );
+}
+
+#[test]
+fn rejected_batch_norm_shape_does_not_mutate_module_state() {
+    let mut registry = LayerRegistry::new();
+    let spec = AgentLayerSpec::batch_norm(8, 2, None).unwrap();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let state_before = registry.get_layer_state(8, LAYER_NORM).unwrap();
+    let wrong_channels = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
+
+    let err = registry
+        .forward_layer(8, LAYER_NORM, &wrong_channels)
+        .unwrap_err();
+    assert!(err.contains("expected axis 1 size 2"));
+
+    let state_after = registry.get_layer_state(8, LAYER_NORM).unwrap();
+    assert_eq!(state_after, state_before);
+}

--- a/tests/burn_contract_baseline.rs
+++ b/tests/burn_contract_baseline.rs
@@ -6,9 +6,8 @@ use burn_research::{WasmBackend, WasmTensor};
 
 #[test]
 fn ndarray_backend_is_explicitly_non_autodiff() {
-    let device = <WasmBackend as Backend>::Device::default();
     assert!(
-        !<WasmBackend as Backend>::ad_enabled(&device),
+        !<WasmBackend as Backend>::ad_enabled(),
         "NdArray baseline must remain non-autodiff; enabling AD changes Burn module semantics and requires a contract audit"
     );
 }
@@ -41,9 +40,10 @@ fn rejected_batch_norm_shape_does_not_mutate_module_state() {
     let state_before = registry.get_layer_state(8, LAYER_NORM).unwrap();
     let wrong_channels = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
 
-    let err = registry
-        .forward_layer(8, LAYER_NORM, &wrong_channels)
-        .unwrap_err();
+    let err = match registry.forward_layer(8, LAYER_NORM, &wrong_channels) {
+        Ok(_) => panic!("BatchNorm unexpectedly accepted a channel-mismatched input"),
+        Err(err) => err,
+    };
     assert!(err.contains("expected axis 1 size 2"));
 
     let state_after = registry.get_layer_state(8, LAYER_NORM).unwrap();


### PR DESCRIPTION
## Scope

Lock the current Burn execution semantics that the agent workflow is allowed to rely on before the full end-to-end audit in #45.

## Baseline decisions

- `burn_ndarray::NdArray<f32>` is the intentional execution baseline; WGPU is not required.
- autodiff is deferred by architecture, not treated as a missing feature.
- the current non-AD backend must keep Burn BatchNorm on inference semantics.

## Proof added

- assert `WasmBackend::ad_enabled(default_device) == false`
- serialize BatchNorm state, run forward twice, and require byte-for-byte unchanged module state
- reject a channel-mismatched BatchNorm input and prove the failed call does not mutate module state
- document which semantics are adapter-owned versus Burn-owned
- require a new Burn contract audit before any future profile enables autodiff or changes stateful forward behavior

## Audit relationship

Issue #45 has been expanded with a Burn contract-conformance phase. This PR does not close #45; it only locks the accepted baseline so the later audit has an explicit reference point.