### PR TITLE
Make syncLayer identity-exact

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -411,6 +411,19 @@ impl AgentWorkspace {
                 spec.layer_id()
             ));
         }
+
+        let actual = registry.layer_init_fingerprint(spec.layer_type(), spec.layer_id())?;
+        let mut expected_registry = LayerRegistry::new();
+        expected_registry.init_agent_layer(spec)?;
+        let expected = expected_registry.layer_init_fingerprint(spec.layer_type(), spec.layer_id())?;
+        if actual != expected {
+            return Err(format!(
+                "AgentWorkspace.syncLayer: registry init identity mismatch for layer type 0x{:02X} id {}; supplied AgentLayerSpec does not match the live layer",
+                spec.layer_type(),
+                spec.layer_id()
+            ));
+        }
+
         let value = format!(
             "label={};type={};variant={}",
             label,

--- a/tests/sync_layer_identity.rs
+++ b/tests/sync_layer_identity.rs
@@ -1,0 +1,67 @@
+use burn_research::agent::AgentLayerSpec;
+use burn_research::protocol::{ACT_RELU, LAYER_ACTIVATION, OP_INIT, PacketHeader};
+use burn_research::registry::LayerRegistry;
+use burn_research::workspace::AgentWorkspace;
+
+#[test]
+fn sync_layer_rejects_same_id_type_wrong_variant_without_mutation() {
+    let mut registry = LayerRegistry::new();
+    let live = AgentLayerSpec::relu(77);
+    registry.init_agent_layer(&live).unwrap();
+
+    let mut workspace = AgentWorkspace::new(4).unwrap();
+    let before = workspace.snapshot();
+    let wrong = AgentLayerSpec::gelu(77);
+
+    let err = workspace
+        .sync_layer(&registry, &wrong, "wrong-variant".into())
+        .unwrap_err();
+    assert!(err.contains("identity mismatch"));
+    assert_eq!(workspace.snapshot(), before);
+    assert_eq!(workspace.get("_layers".into(), "77".into()), "null");
+}
+
+#[test]
+fn sync_layer_rejects_same_variant_wrong_payload_without_mutation() {
+    let mut registry = LayerRegistry::new();
+    let live = AgentLayerSpec::linear(81, 4, 3, true).unwrap();
+    registry.init_agent_layer(&live).unwrap();
+
+    let mut workspace = AgentWorkspace::new(4).unwrap();
+    let before = workspace.snapshot();
+    let wrong = AgentLayerSpec::linear(81, 4, 5, true).unwrap();
+
+    let err = workspace
+        .sync_layer(&registry, &wrong, "wrong-payload".into())
+        .unwrap_err();
+    assert!(err.contains("identity mismatch"));
+    assert_eq!(workspace.snapshot(), before);
+    assert_eq!(workspace.get("_layers".into(), "81".into()), "null");
+}
+
+#[test]
+fn raw_protocol_layer_still_reconciles_when_identity_matches() {
+    let layer_id = 90u32;
+    let payload = layer_id.to_le_bytes();
+    let header = PacketHeader {
+        opcode: OP_INIT,
+        layer_type: LAYER_ACTIVATION,
+        variant: ACT_RELU,
+        flags: 0,
+        payload_len: payload.len() as u32,
+    };
+
+    let mut registry = LayerRegistry::new();
+    registry.init_layer(&header, &payload).unwrap();
+
+    let mut workspace = AgentWorkspace::new(4).unwrap();
+    let matching_spec = AgentLayerSpec::relu(layer_id);
+    workspace
+        .sync_layer(&registry, &matching_spec, "raw-relu".into())
+        .unwrap();
+
+    let row = workspace.get("_layers".into(), layer_id.to_string());
+    assert!(row.contains("initialized"));
+    assert!(row.contains("raw-relu"));
+    assert!(registry.layer_exists(LAYER_ACTIVATION, layer_id));
+}


### PR DESCRIPTION
Fixes #52 as part of audit #45.

- keep `AgentWorkspace.syncLayer()` public
- compare the live Registry init fingerprint against the exact fingerprint implied by the supplied `AgentLayerSpec`
- reject same-id/type variant or payload mismatches before workspace mutation
- preserve successful raw/manual protocol -> workspace reconciliation
- no Burn, GraphBuilder, or execution semantics changes

Regression tests cover wrong variant, wrong payload, no-mutation, and successful raw protocol reconciliation.