### PR TITLE
Run integration tests in the host CI gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         run: python3 scripts/check_wasm_surface.py
 
       - name: Run host tests
-        run: cargo test --lib
+        run: cargo test --lib --tests
 
       - name: Report artifact size
         run: |


### PR DESCRIPTION
Fixes #58 as part of end-to-end audit #45.

- change the host test gate from `cargo test --lib` to `cargo test --lib --tests`
- execute integration proof files under `tests/` instead of only compiling them indirectly
- preserve packaged WASM surface audit, wasm32 check, Binaryen verification, and artifact upload
- do not weaken any test; any newly surfaced failure is treated as an audit finding

No production runtime or Burn semantics are changed.