### PR TITLE
Audit Burn module and record ownership conformance

### DIFF
--- a/src/layers/activation.rs
+++ b/src/layers/activation.rs
@@ -286,9 +286,11 @@ impl WasmActivation {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = BinBytesRecorder::<FullPrecisionSettings>::default()
-            .load(data.to_vec(), &device)
-            .map_err(|e| e.to_string())?;
+        let record = crate::layers::state_record::decode_bin_record(
+            data,
+            &device,
+            "Activation loadState",
+        )?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/conv.rs
+++ b/src/layers/conv.rs
@@ -166,9 +166,11 @@ impl WasmConv {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = BinBytesRecorder::<FullPrecisionSettings>::default()
-            .load(data.to_vec(), &device)
-            .map_err(|e| e.to_string())?;
+        let record = crate::layers::state_record::decode_bin_record(
+            data,
+            &device,
+            "Conv loadState",
+        )?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/custom/ghost.rs
+++ b/src/layers/custom/ghost.rs
@@ -153,9 +153,11 @@ impl WasmGhostModule {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = BinBytesRecorder::<FullPrecisionSettings>::default()
-            .load(data.to_vec(), &device)
-            .map_err(|e| e.to_string())?;
+        let record = crate::layers::state_record::decode_bin_record(
+            data,
+            &device,
+            "GhostModule loadState",
+        )?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/custom/seblock.rs
+++ b/src/layers/custom/seblock.rs
@@ -125,9 +125,11 @@ impl WasmSeBlock {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = BinBytesRecorder::<FullPrecisionSettings>::default()
-            .load(data.to_vec(), &device)
-            .map_err(|e| e.to_string())?;
+        let record = crate::layers::state_record::decode_bin_record(
+            data,
+            &device,
+            "SEBlock loadState",
+        )?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/embedding.rs
+++ b/src/layers/embedding.rs
@@ -107,9 +107,11 @@ impl WasmEmbedding {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = BinBytesRecorder::<FullPrecisionSettings>::default()
-            .load(data.to_vec(), &device)
-            .map_err(|e| e.to_string())?;
+        let record = crate::layers::state_record::decode_bin_record(
+            data,
+            &device,
+            "Embedding loadState",
+        )?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/linear.rs
+++ b/src/layers/linear.rs
@@ -64,11 +64,11 @@ impl WasmLinear {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = BinBytesRecorder::<FullPrecisionSettings>::default()
-            .load(data.to_vec(), &device)
-            .map_err(|e| e.to_string())?;
-            
-        // PERBAIKAN: Clone dulu sebelum load_record
+        let record = crate::layers::state_record::decode_bin_record(
+            data,
+            &device,
+            "Linear loadState",
+        )?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -8,3 +8,4 @@ pub mod binary;
 pub mod custom;
 pub mod layout;
 pub(crate) mod shape_contract;
+pub(crate) mod state_record;

--- a/src/layers/norm.rs
+++ b/src/layers/norm.rs
@@ -149,11 +149,11 @@ impl WasmNorm {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = BinBytesRecorder::<FullPrecisionSettings>::default()
-            .load(data.to_vec(), &device)
-            .map_err(|e| e.to_string())?;
-            
-        // PERBAIKAN: Clone dulu
+        let record = crate::layers::state_record::decode_bin_record(
+            data,
+            &device,
+            "Norm loadState",
+        )?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/state_record.rs
+++ b/src/layers/state_record.rs
@@ -1,0 +1,21 @@
+use burn::record::{BurnRecord, FullPrecisionSettings, Record};
+use burn::tensor::backend::Backend;
+
+/// Decode the same bincode payload used by Burn's `BinBytesRecorder`, but keep
+/// malformed/untrusted bytes on our fallible boundary instead of reaching the
+/// recorder's internal `unwrap()` in Burn 0.20.1.
+pub(crate) fn decode_bin_record<B, R>(
+    data: &[u8],
+    device: &B::Device,
+    context: &str,
+) -> Result<R, String>
+where
+    B: Backend,
+    R: Record<B>,
+{
+    let (record, _consumed): (BurnRecord<R::Item<FullPrecisionSettings>, B>, usize) =
+        bincode::serde::decode_from_slice(data, bincode::config::standard())
+            .map_err(|err| format!("{context}: invalid Burn bincode record: {err}"))?;
+
+    Ok(R::from_item::<FullPrecisionSettings>(record.item, device))
+}

--- a/tests/burn_module_conformance.rs
+++ b/tests/burn_module_conformance.rs
@@ -16,6 +16,13 @@ fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
     }
 }
 
+fn expect_err_without_debug<T, E>(result: Result<T, E>) -> E {
+    match result {
+        Ok(_) => panic!("expected operation to fail"),
+        Err(err) => err,
+    }
+}
+
 #[test]
 fn direct_burn_record_registry_and_compiled_graph_preserve_linear_semantics() {
     let direct = WasmLinear::new(3, 2, true);
@@ -138,7 +145,7 @@ fn linear_shape_adapter_rejects_hidden_spatial_data_without_state_mutation_then_
     let state_before = registry.get_layer_state(31, LAYER_LINEAR).unwrap();
 
     let invalid = WasmTensor::new(&[1.0; 6], &[1, 3, 2, 1]);
-    let err = registry.forward_layer(31, LAYER_LINEAR, &invalid).unwrap_err();
+    let err = expect_err_without_debug(registry.forward_layer(31, LAYER_LINEAR, &invalid));
     assert!(err.contains("axis 2"));
     assert_eq!(registry.get_layer_state(31, LAYER_LINEAR).unwrap(), state_before);
 
@@ -156,11 +163,11 @@ fn one_dimensional_conv_and_pool_reject_hidden_width_then_accept_canonical_rank4
 
     let conv_state_before = registry.get_layer_state(32, LAYER_CONV).unwrap();
     let invalid = WasmTensor::new(&[1.0; 10], &[1, 1, 5, 2]);
-    let conv_err = registry.forward_layer(32, LAYER_CONV, &invalid).unwrap_err();
+    let conv_err = expect_err_without_debug(registry.forward_layer(32, LAYER_CONV, &invalid));
     assert!(conv_err.contains("axis 3"));
     assert_eq!(registry.get_layer_state(32, LAYER_CONV).unwrap(), conv_state_before);
 
-    let pool_err = registry.forward_layer(33, LAYER_POOL, &invalid).unwrap_err();
+    let pool_err = expect_err_without_debug(registry.forward_layer(33, LAYER_POOL, &invalid));
     assert!(pool_err.contains("axis 3"));
 
     let valid = WasmTensor::new(&[1.0, 2.0, 3.0, 4.0, 5.0], &[1, 1, 5, 1]);

--- a/tests/burn_module_conformance.rs
+++ b/tests/burn_module_conformance.rs
@@ -1,0 +1,194 @@
+use burn_research::agent::{AgentGraphBuilder, AgentLayerSpec};
+use burn_research::layers::linear::WasmLinear;
+use burn_research::protocol::{
+    LAYER_CONV, LAYER_EMBEDDING, LAYER_LINEAR, LAYER_NORM, LAYER_POOL,
+};
+use burn_research::registry::LayerRegistry;
+use burn_research::WasmTensor;
+
+fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "value mismatch at {index}: actual={actual}, expected={expected}, tolerance={tolerance}"
+        );
+    }
+}
+
+#[test]
+fn direct_burn_record_registry_and_compiled_graph_preserve_linear_semantics() {
+    let direct = WasmLinear::new(3, 2, true);
+    let direct_state = direct.get_state().unwrap();
+    let input = WasmTensor::new(&[1.0, -2.0, 0.5, 3.0, 1.0, -1.0], &[2, 3, 1, 1]);
+    let direct_output = direct.forward(&input).to_array();
+
+    let spec = AgentLayerSpec::linear(11, 3, 2, true).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+    registry
+        .load_layer_state(spec.layer_id(), LAYER_LINEAR, &direct_state)
+        .unwrap();
+
+    let registry_output = registry
+        .forward_layer(spec.layer_id(), LAYER_LINEAR, &input)
+        .unwrap()
+        .to_array();
+    assert_close(&registry_output, &direct_output, 1e-6);
+
+    let mut builder = AgentGraphBuilder::new(2).unwrap();
+    builder.add_unary(&spec, 0, 1).unwrap();
+    let graph = builder.compile_with_output(&registry, 1).unwrap();
+    let graph_output = graph.run(&registry, &input).unwrap().to_array();
+    assert_close(&graph_output, &direct_output, 1e-6);
+}
+
+#[test]
+fn malformed_record_load_is_no_mutation_and_registry_remains_retryable() {
+    let spec = AgentLayerSpec::linear(12, 3, 2, true).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let state_before = registry.get_layer_state(12, LAYER_LINEAR).unwrap();
+    let weights_before = registry.get_weights_flat(12, LAYER_LINEAR).unwrap();
+    let params_before = registry.total_params();
+
+    assert!(registry
+        .load_layer_state(12, LAYER_LINEAR, &[0xde, 0xad, 0xbe, 0xef])
+        .is_err());
+    assert_eq!(registry.get_layer_state(12, LAYER_LINEAR).unwrap(), state_before);
+    assert_eq!(registry.get_weights_flat(12, LAYER_LINEAR).unwrap(), weights_before);
+    assert_eq!(registry.total_params(), params_before);
+
+    registry
+        .load_layer_state(12, LAYER_LINEAR, &state_before)
+        .unwrap();
+    let input = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
+    assert!(registry.forward_layer(12, LAYER_LINEAR, &input).is_ok());
+}
+
+#[test]
+fn wrong_length_weight_update_is_no_mutation_and_retryable() {
+    let spec = AgentLayerSpec::linear(13, 3, 2, true).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let state_before = registry.get_layer_state(13, LAYER_LINEAR).unwrap();
+    let weights_before = registry.get_weights_flat(13, LAYER_LINEAR).unwrap();
+    let params_before = registry.total_params();
+    let wrong = vec![0.0; weights_before.len() - 1];
+
+    assert!(registry.set_weights_flat(13, LAYER_LINEAR, &wrong).is_err());
+    assert_eq!(registry.get_layer_state(13, LAYER_LINEAR).unwrap(), state_before);
+    assert_eq!(registry.get_weights_flat(13, LAYER_LINEAR).unwrap(), weights_before);
+    assert_eq!(registry.total_params(), params_before);
+
+    let replacement = weights_before
+        .iter()
+        .map(|value| value + 0.125)
+        .collect::<Vec<_>>();
+    registry
+        .set_weights_flat(13, LAYER_LINEAR, &replacement)
+        .unwrap();
+    assert_eq!(registry.get_weights_flat(13, LAYER_LINEAR).unwrap(), replacement);
+    assert_eq!(registry.total_params(), params_before);
+}
+
+#[test]
+fn batch_norm_optimizer_bridge_exposes_only_trainable_state_and_forward_is_non_mutating() {
+    let spec = AgentLayerSpec::batch_norm(21, 2, None).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let layout = registry.weight_layout(21, LAYER_NORM).unwrap();
+    assert!(layout.contains("gamma"));
+    assert!(layout.contains("beta"));
+    assert!(!layout.contains("running_mean"));
+    assert!(!layout.contains("running_var"));
+
+    let weights = registry.get_weights_flat(21, LAYER_NORM).unwrap();
+    assert_eq!(weights.len(), 4, "BatchNorm(2) optimizer bridge must be gamma(2)+beta(2)");
+
+    let state_before_bad_update = registry.get_layer_state(21, LAYER_NORM).unwrap();
+    assert!(registry.set_weights_flat(21, LAYER_NORM, &[1.0, 1.0, 0.0]).is_err());
+    assert_eq!(
+        registry.get_layer_state(21, LAYER_NORM).unwrap(),
+        state_before_bad_update
+    );
+
+    registry
+        .set_weights_flat(21, LAYER_NORM, &[2.0, 3.0, 0.5, -0.25])
+        .unwrap();
+    let state_after_weight_update = registry.get_layer_state(21, LAYER_NORM).unwrap();
+    let input = WasmTensor::new(&[1.0, 2.0, 3.0, 4.0], &[2, 2, 1, 1]);
+    registry.forward_layer(21, LAYER_NORM, &input).unwrap();
+    registry.forward_layer(21, LAYER_NORM, &input).unwrap();
+    assert_eq!(
+        registry.get_layer_state(21, LAYER_NORM).unwrap(),
+        state_after_weight_update,
+        "non-AD NdArray BatchNorm forward must not mutate serialized running state"
+    );
+}
+
+#[test]
+fn linear_shape_adapter_rejects_hidden_spatial_data_without_state_mutation_then_retries() {
+    let spec = AgentLayerSpec::linear(31, 3, 2, true).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+    let state_before = registry.get_layer_state(31, LAYER_LINEAR).unwrap();
+
+    let invalid = WasmTensor::new(&[1.0; 6], &[1, 3, 2, 1]);
+    let err = registry.forward_layer(31, LAYER_LINEAR, &invalid).unwrap_err();
+    assert!(err.contains("axis 2"));
+    assert_eq!(registry.get_layer_state(31, LAYER_LINEAR).unwrap(), state_before);
+
+    let valid = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
+    assert!(registry.forward_layer(31, LAYER_LINEAR, &valid).is_ok());
+}
+
+#[test]
+fn one_dimensional_conv_and_pool_reject_hidden_width_then_accept_canonical_rank4_adapter() {
+    let conv = AgentLayerSpec::conv1d(32, 1, 2, 3, None, None).unwrap();
+    let pool = AgentLayerSpec::max_pool1d(33, 2, None, None).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&conv).unwrap();
+    registry.init_agent_layer(&pool).unwrap();
+
+    let conv_state_before = registry.get_layer_state(32, LAYER_CONV).unwrap();
+    let invalid = WasmTensor::new(&[1.0; 10], &[1, 1, 5, 2]);
+    let conv_err = registry.forward_layer(32, LAYER_CONV, &invalid).unwrap_err();
+    assert!(conv_err.contains("axis 3"));
+    assert_eq!(registry.get_layer_state(32, LAYER_CONV).unwrap(), conv_state_before);
+
+    let pool_err = registry.forward_layer(33, LAYER_POOL, &invalid).unwrap_err();
+    assert!(pool_err.contains("axis 3"));
+
+    let valid = WasmTensor::new(&[1.0, 2.0, 3.0, 4.0, 5.0], &[1, 1, 5, 1]);
+    let conv_out = registry.forward_layer(32, LAYER_CONV, &valid).unwrap();
+    assert_eq!(conv_out.shape()[3], 1);
+    let pool_out = registry.forward_layer(33, LAYER_POOL, &valid).unwrap();
+    assert_eq!(pool_out.shape()[3], 1);
+}
+
+#[test]
+fn embedding_validates_float_bridge_indices_before_burn_integer_conversion_and_retries() {
+    let spec = AgentLayerSpec::embedding(34, 4, 3).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+    let state_before = registry.get_layer_state(34, LAYER_EMBEDDING).unwrap();
+
+    for invalid_values in [
+        vec![0.0, 1.5],
+        vec![-1.0, 1.0],
+        vec![0.0, 4.0],
+        vec![0.0, f32::NAN],
+    ] {
+        let invalid = WasmTensor::new(&invalid_values, &[1, 2, 1, 1]);
+        assert!(registry.forward_layer(34, LAYER_EMBEDDING, &invalid).is_err());
+        assert_eq!(registry.get_layer_state(34, LAYER_EMBEDDING).unwrap(), state_before);
+    }
+
+    let valid = WasmTensor::new(&[0.0, 1.0, 3.0], &[1, 3, 1, 1]);
+    let output = registry.forward_layer(34, LAYER_EMBEDDING, &valid).unwrap();
+    assert_eq!(output.shape(), vec![1, 3, 3, 1]);
+}

--- a/tests/burn_module_conformance.rs
+++ b/tests/burn_module_conformance.rs
@@ -1,7 +1,8 @@
 use burn_research::agent::{AgentGraphBuilder, AgentLayerSpec};
 use burn_research::layers::linear::WasmLinear;
 use burn_research::protocol::{
-    LAYER_CONV, LAYER_EMBEDDING, LAYER_LINEAR, LAYER_NORM, LAYER_POOL,
+    LAYER_ACTIVATION, LAYER_CONV, LAYER_EMBEDDING, LAYER_GHOST, LAYER_LINEAR, LAYER_NORM,
+    LAYER_POOL, LAYER_SEBLOCK,
 };
 use burn_research::registry::LayerRegistry;
 use burn_research::WasmTensor;
@@ -72,6 +73,48 @@ fn malformed_record_load_is_no_mutation_and_registry_remains_retryable() {
         .unwrap();
     let input = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
     assert!(registry.forward_layer(12, LAYER_LINEAR, &input).is_ok());
+}
+
+#[test]
+fn malformed_record_bytes_fail_closed_for_every_stateful_layer_family() {
+    let cases = vec![
+        (AgentLayerSpec::linear(40, 3, 2, true).unwrap(), LAYER_LINEAR),
+        (AgentLayerSpec::batch_norm(41, 2, None).unwrap(), LAYER_NORM),
+        (AgentLayerSpec::conv1d(42, 1, 2, 3, None, None).unwrap(), LAYER_CONV),
+        (AgentLayerSpec::embedding(43, 4, 3).unwrap(), LAYER_EMBEDDING),
+        (AgentLayerSpec::prelu(44, 1, 0.25).unwrap(), LAYER_ACTIVATION),
+        (
+            AgentLayerSpec::ghost(45, 2, 4, 1, 1, 2, None, None, None, None).unwrap(),
+            LAYER_GHOST,
+        ),
+        (AgentLayerSpec::se_block(46, 4, 2).unwrap(), LAYER_SEBLOCK),
+    ];
+
+    let mut registry = LayerRegistry::new();
+    for (spec, layer_type) in cases {
+        registry.init_agent_layer(&spec).unwrap();
+        let layer_id = spec.layer_id();
+        let state_before = registry.get_layer_state(layer_id, layer_type).unwrap();
+        let params_before = registry.total_params();
+
+        let error = registry
+            .load_layer_state(layer_id, layer_type, &[0xde, 0xad, 0xbe, 0xef])
+            .expect_err("malformed Burn record must be rejected");
+        assert!(
+            error.contains("invalid Burn bincode record"),
+            "unexpected malformed-state error for type 0x{layer_type:02X}: {error}"
+        );
+        assert_eq!(
+            registry.get_layer_state(layer_id, layer_type).unwrap(),
+            state_before,
+            "malformed state mutated layer type 0x{layer_type:02X} id {layer_id}"
+        );
+        assert_eq!(registry.total_params(), params_before);
+
+        registry
+            .load_layer_state(layer_id, layer_type, &state_before)
+            .unwrap();
+    }
 }
 
 #[test]
@@ -175,6 +218,28 @@ fn one_dimensional_conv_and_pool_reject_hidden_width_then_accept_canonical_rank4
     assert_eq!(conv_out.shape()[3], 1);
     let pool_out = registry.forward_layer(33, LAYER_POOL, &valid).unwrap();
     assert_eq!(pool_out.shape()[3], 1);
+}
+
+#[test]
+fn conv2d_adapter_preserves_canonical_rank4_spatial_semantics() {
+    let spec = AgentLayerSpec::conv2d(
+        35,
+        1,
+        2,
+        3,
+        3,
+        None,
+        None,
+        Some(1),
+        Some(1),
+    )
+    .unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let input = WasmTensor::new(&[1.0; 16], &[1, 1, 4, 4]);
+    let output = registry.forward_layer(35, LAYER_CONV, &input).unwrap();
+    assert_eq!(output.shape(), vec![1, 2, 4, 4]);
 }
 
 #[test]


### PR DESCRIPTION
Advances #60 as part of end-to-end audit #45.

Adds CI-executed Burn/NdArray conformance proofs and hardens a real malformed-record boundary discovered by those proofs.

Audit/proof coverage:
- direct WasmLinear Burn record -> LayerRegistry -> CompiledGraph preserves forward semantics
- malformed state bytes must return a controlled error, preserve exact pre-call state/params, and allow retry
- the malformed-state proof now covers every stateful family using Burn binary records: Linear, Norm, Conv, Embedding, Activation, GhostModule, and SEBlock
- wrong-length setWeightsFlat is no-mutation and retryable
- BatchNorm optimizer-visible layout contains gamma/beta but not running mean/variance; non-AD forward preserves serialized state
- Linear rejects hidden spatial data before execution and remains reusable
- Conv1d/Pool1d reject non-singleton width before rank adaptation, then accept canonical rank-4 input
- Conv2d canonical rank-4 spatial semantics are exercised
- Embedding rejects fractional, negative, out-of-range, and non-finite float indices before Burn integer conversion, then accepts valid indices

Production hardening discovered by the audit:
- Burn 0.20.1 BinBytesRecorder::load_item internally unwraps malformed bincode input, so untrusted/truncated bytes could panic instead of satisfying our Err + no-mutation contract
- state loaders now decode the same Burn bincode record format through a fallible adapter before load_record, preserving valid serialized-state compatibility while rejecting malformed bytes before Burn's panic path

WGPU and autodiff remain intentionally out of scope. Burn numerical kernels and forward semantics are not replaced.