### PR TITLE
Audit execution-state mutation and provenance conformance

### DIFF
--- a/src/layers/activation.rs
+++ b/src/layers/activation.rs
@@ -158,6 +158,67 @@ impl<B: Backend> Activation<B> {
     }
 }
 
+fn validate_activation_linear_state(
+    context: &str,
+    expected: &burn::nn::LinearRecord<WasmBackend>,
+    actual: &burn::nn::LinearRecord<WasmBackend>,
+) -> Result<(), String> {
+    if expected.weight.dims() != actual.weight.dims() {
+        return Err(format!(
+            "Activation loadState: {context} weight shape mismatch: expected {:?}, got {:?}",
+            expected.weight.dims(),
+            actual.weight.dims()
+        ));
+    }
+    match (&expected.bias, &actual.bias) {
+        (None, None) => Ok(()),
+        (Some(expected), Some(actual)) if expected.dims() == actual.dims() => Ok(()),
+        (Some(expected), Some(actual)) => Err(format!(
+            "Activation loadState: {context} bias shape mismatch: expected {:?}, got {:?}",
+            expected.dims(),
+            actual.dims()
+        )),
+        _ => Err(format!(
+            "Activation loadState: {context} bias presence mismatch"
+        )),
+    }
+}
+
+fn validate_activation_state_structure(
+    current: &ActivationRecord<WasmBackend>,
+    incoming: &ActivationRecord<WasmBackend>,
+) -> Result<(), String> {
+    if std::mem::discriminant(current) != std::mem::discriminant(incoming) {
+        return Err("Activation loadState: activation variant mismatch".to_string());
+    }
+
+    match (current, incoming) {
+        (ActivationRecord::PRelu(expected), ActivationRecord::PRelu(actual)) => {
+            if expected.alpha.dims() != actual.alpha.dims() {
+                return Err(format!(
+                    "Activation loadState: PRelu alpha shape mismatch: expected {:?}, got {:?}",
+                    expected.alpha.dims(),
+                    actual.alpha.dims()
+                ));
+            }
+            Ok(())
+        }
+        (ActivationRecord::SwiGlu(expected), ActivationRecord::SwiGlu(actual)) => {
+            validate_activation_linear_state(
+                "SwiGlu.linear_inner",
+                &expected.linear_inner,
+                &actual.linear_inner,
+            )?;
+            validate_activation_linear_state(
+                "SwiGlu.linear_outer",
+                &expected.linear_outer,
+                &actual.linear_outer,
+            )
+        }
+        _ => Ok(()),
+    }
+}
+
 // --- WASM WRAPPER ---
 #[wasm_bindgen]
 pub struct WasmActivation {
@@ -286,11 +347,13 @@ impl WasmActivation {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = crate::layers::state_record::decode_bin_record(
+        let record: ActivationRecord<WasmBackend> = crate::layers::state_record::decode_bin_record(
             data,
             &device,
             "Activation loadState",
         )?;
+        let current = self.inner.clone().into_record();
+        validate_activation_state_structure(&current, &record)?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/conv.rs
+++ b/src/layers/conv.rs
@@ -87,6 +87,48 @@ impl<B: Backend> Convolution<B> {
     }
 }
 
+fn validate_conv_params<const D: usize>(
+    expected_weight: &burn::module::Param<Tensor<WasmBackend, D>>,
+    expected_bias: &Option<burn::module::Param<Tensor<WasmBackend, 1>>>,
+    actual_weight: &burn::module::Param<Tensor<WasmBackend, D>>,
+    actual_bias: &Option<burn::module::Param<Tensor<WasmBackend, 1>>>,
+) -> Result<(), String> {
+    if expected_weight.dims() != actual_weight.dims() {
+        return Err(format!(
+            "Conv loadState: weight shape mismatch: expected {:?}, got {:?}",
+            expected_weight.dims(),
+            actual_weight.dims()
+        ));
+    }
+    match (expected_bias, actual_bias) {
+        (None, None) => Ok(()),
+        (Some(expected), Some(actual)) if expected.dims() == actual.dims() => Ok(()),
+        (Some(expected), Some(actual)) => Err(format!(
+            "Conv loadState: bias shape mismatch: expected {:?}, got {:?}",
+            expected.dims(),
+            actual.dims()
+        )),
+        _ => Err("Conv loadState: bias presence mismatch".to_string()),
+    }
+}
+
+fn validate_conv_state_structure(
+    current: &ConvolutionRecord<WasmBackend>,
+    incoming: &ConvolutionRecord<WasmBackend>,
+) -> Result<(), String> {
+    match (current, incoming) {
+        (ConvolutionRecord::Conv1d(expected), ConvolutionRecord::Conv1d(actual)) =>
+            validate_conv_params::<3>(&expected.weight, &expected.bias, &actual.weight, &actual.bias),
+        (ConvolutionRecord::Conv2d(expected), ConvolutionRecord::Conv2d(actual)) =>
+            validate_conv_params::<4>(&expected.weight, &expected.bias, &actual.weight, &actual.bias),
+        (
+            ConvolutionRecord::ConvTranspose2d(expected),
+            ConvolutionRecord::ConvTranspose2d(actual),
+        ) => validate_conv_params::<4>(&expected.weight, &expected.bias, &actual.weight, &actual.bias),
+        _ => Err("Conv loadState: convolution variant mismatch".to_string()),
+    }
+}
+
 // --- WASM WRAPPER ---
 #[wasm_bindgen]
 pub struct WasmConv {
@@ -166,11 +208,13 @@ impl WasmConv {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = crate::layers::state_record::decode_bin_record(
+        let record: ConvolutionRecord<WasmBackend> = crate::layers::state_record::decode_bin_record(
             data,
             &device,
             "Conv loadState",
         )?;
+        let current = self.inner.clone().into_record();
+        validate_conv_state_structure(&current, &record)?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/custom/ghost.rs
+++ b/src/layers/custom/ghost.rs
@@ -105,6 +105,54 @@ impl<B: Backend> GhostModule<B> {
     }
 }
 
+fn validate_conv2d_params(
+    context: &str,
+    expected_weight: &burn::module::Param<Tensor<WasmBackend, 4>>,
+    expected_bias: &Option<burn::module::Param<Tensor<WasmBackend, 1>>>,
+    actual_weight: &burn::module::Param<Tensor<WasmBackend, 4>>,
+    actual_bias: &Option<burn::module::Param<Tensor<WasmBackend, 1>>>,
+) -> Result<(), String> {
+    if expected_weight.dims() != actual_weight.dims() {
+        return Err(format!(
+            "GhostModule loadState: {context} weight shape mismatch: expected {:?}, got {:?}",
+            expected_weight.dims(),
+            actual_weight.dims()
+        ));
+    }
+    match (expected_bias, actual_bias) {
+        (None, None) => Ok(()),
+        (Some(expected), Some(actual)) if expected.dims() == actual.dims() => Ok(()),
+        (Some(expected), Some(actual)) => Err(format!(
+            "GhostModule loadState: {context} bias shape mismatch: expected {:?}, got {:?}",
+            expected.dims(),
+            actual.dims()
+        )),
+        _ => Err(format!(
+            "GhostModule loadState: {context} bias presence mismatch"
+        )),
+    }
+}
+
+fn validate_ghost_state_structure(
+    current: &GhostModuleRecord<WasmBackend>,
+    incoming: &GhostModuleRecord<WasmBackend>,
+) -> Result<(), String> {
+    validate_conv2d_params(
+        "primary",
+        &current.primary.weight,
+        &current.primary.bias,
+        &incoming.primary.weight,
+        &incoming.primary.bias,
+    )?;
+    validate_conv2d_params(
+        "cheap",
+        &current.cheap.weight,
+        &current.cheap.bias,
+        &incoming.cheap.weight,
+        &incoming.cheap.bias,
+    )
+}
+
 // --- WASM WRAPPER ---
 #[wasm_bindgen]
 pub struct WasmGhostModule {
@@ -153,11 +201,13 @@ impl WasmGhostModule {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = crate::layers::state_record::decode_bin_record(
+        let record: GhostModuleRecord<WasmBackend> = crate::layers::state_record::decode_bin_record(
             data,
             &device,
             "GhostModule loadState",
         )?;
+        let current = self.inner.clone().into_record();
+        validate_ghost_state_structure(&current, &record)?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/custom/seblock.rs
+++ b/src/layers/custom/seblock.rs
@@ -94,6 +94,54 @@ impl<B: Backend> SeBlock<B> {
     }
 }
 
+fn validate_linear_params(
+    context: &str,
+    expected_weight: &burn::module::Param<Tensor<WasmBackend, 2>>,
+    expected_bias: &Option<burn::module::Param<Tensor<WasmBackend, 1>>>,
+    actual_weight: &burn::module::Param<Tensor<WasmBackend, 2>>,
+    actual_bias: &Option<burn::module::Param<Tensor<WasmBackend, 1>>>,
+) -> Result<(), String> {
+    if expected_weight.dims() != actual_weight.dims() {
+        return Err(format!(
+            "SEBlock loadState: {context} weight shape mismatch: expected {:?}, got {:?}",
+            expected_weight.dims(),
+            actual_weight.dims()
+        ));
+    }
+    match (expected_bias, actual_bias) {
+        (None, None) => Ok(()),
+        (Some(expected), Some(actual)) if expected.dims() == actual.dims() => Ok(()),
+        (Some(expected), Some(actual)) => Err(format!(
+            "SEBlock loadState: {context} bias shape mismatch: expected {:?}, got {:?}",
+            expected.dims(),
+            actual.dims()
+        )),
+        _ => Err(format!(
+            "SEBlock loadState: {context} bias presence mismatch"
+        )),
+    }
+}
+
+fn validate_seblock_state_structure(
+    current: &SeBlockRecord<WasmBackend>,
+    incoming: &SeBlockRecord<WasmBackend>,
+) -> Result<(), String> {
+    validate_linear_params(
+        "fc1",
+        &current.fc1.weight,
+        &current.fc1.bias,
+        &incoming.fc1.weight,
+        &incoming.fc1.bias,
+    )?;
+    validate_linear_params(
+        "fc2",
+        &current.fc2.weight,
+        &current.fc2.bias,
+        &incoming.fc2.weight,
+        &incoming.fc2.bias,
+    )
+}
+
 // --- WASM WRAPPER ---
 #[wasm_bindgen]
 pub struct WasmSeBlock {
@@ -125,11 +173,13 @@ impl WasmSeBlock {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = crate::layers::state_record::decode_bin_record(
+        let record: SeBlockRecord<WasmBackend> = crate::layers::state_record::decode_bin_record(
             data,
             &device,
             "SEBlock loadState",
         )?;
+        let current = self.inner.clone().into_record();
+        validate_seblock_state_structure(&current, &record)?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/embedding.rs
+++ b/src/layers/embedding.rs
@@ -79,6 +79,24 @@ impl<B: Backend> EmbeddingLayer<B> {
     }
 }
 
+fn validate_embedding_state_structure(
+    current: &EmbeddingLayerRecord<WasmBackend>,
+    incoming: &EmbeddingLayerRecord<WasmBackend>,
+) -> Result<(), String> {
+    match (current, incoming) {
+        (EmbeddingLayerRecord::Basic(expected), EmbeddingLayerRecord::Basic(actual)) => {
+            if expected.weight.dims() != actual.weight.dims() {
+                return Err(format!(
+                    "Embedding loadState: weight shape mismatch: expected {:?}, got {:?}",
+                    expected.weight.dims(),
+                    actual.weight.dims()
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
 // --- WASM WRAPPER ---
 #[wasm_bindgen]
 pub struct WasmEmbedding {
@@ -107,11 +125,13 @@ impl WasmEmbedding {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = crate::layers::state_record::decode_bin_record(
+        let record: EmbeddingLayerRecord<WasmBackend> = crate::layers::state_record::decode_bin_record(
             data,
             &device,
             "Embedding loadState",
         )?;
+        let current = self.inner.clone().into_record();
+        validate_embedding_state_structure(&current, &record)?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/linear.rs
+++ b/src/layers/linear.rs
@@ -64,11 +64,33 @@ impl WasmLinear {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = crate::layers::state_record::decode_bin_record(
+        let record: LinearLayerRecord<WasmBackend> = crate::layers::state_record::decode_bin_record(
             data,
             &device,
             "Linear loadState",
         )?;
+        let current = self.inner.clone().into_record();
+        if record.inner.weight.dims() != current.inner.weight.dims() {
+            return Err(format!(
+                "Linear loadState: weight shape mismatch: expected {:?}, got {:?}",
+                current.inner.weight.dims(),
+                record.inner.weight.dims()
+            ));
+        }
+        match (&current.inner.bias, &record.inner.bias) {
+            (None, None) => {}
+            (Some(expected), Some(actual)) if expected.dims() == actual.dims() => {}
+            (Some(expected), Some(actual)) => {
+                return Err(format!(
+                    "Linear loadState: bias shape mismatch: expected {:?}, got {:?}",
+                    expected.dims(),
+                    actual.dims()
+                ));
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                return Err("Linear loadState: bias presence mismatch".to_string());
+            }
+        }
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/norm.rs
+++ b/src/layers/norm.rs
@@ -97,6 +97,32 @@ impl<B: Backend> Normalization<B> {
     }
 }
 
+fn validate_norm_state_structure(
+    current: &NormalizationRecord<WasmBackend>,
+    incoming: &NormalizationRecord<WasmBackend>,
+) -> Result<(), String> {
+    if std::mem::discriminant(current) != std::mem::discriminant(incoming) {
+        return Err("Norm loadState: normalization variant mismatch".to_string());
+    }
+
+    let param_shapes = |record: &NormalizationRecord<WasmBackend>| {
+        let (gamma, beta) = norm_trainable_refs(record);
+        (
+            gamma.map(|param| param.dims().to_vec()),
+            beta.map(|param| param.dims().to_vec()),
+        )
+    };
+    let expected = param_shapes(current);
+    let actual = param_shapes(incoming);
+    if expected != actual {
+        return Err(format!(
+            "Norm loadState: parameter structure mismatch: expected {:?}, got {:?}",
+            expected, actual
+        ));
+    }
+    Ok(())
+}
+
 // --- WASM WRAPPER ---
 #[wasm_bindgen]
 pub struct WasmNorm {
@@ -149,11 +175,13 @@ impl WasmNorm {
 
     pub fn load_state(&mut self, data: &[u8]) -> Result<(), String> {
         let device = Default::default();
-        let record = crate::layers::state_record::decode_bin_record(
+        let record: NormalizationRecord<WasmBackend> = crate::layers::state_record::decode_bin_record(
             data,
             &device,
             "Norm loadState",
         )?;
+        let current = self.inner.clone().into_record();
+        validate_norm_state_structure(&current, &record)?;
         self.inner = self.inner.clone().load_record(record);
         Ok(())
     }

--- a/src/layers/state_record.rs
+++ b/src/layers/state_record.rs
@@ -1,9 +1,9 @@
 use burn::record::{BurnRecord, FullPrecisionSettings, Record};
 use burn::tensor::backend::Backend;
 
-/// Decode the same bincode payload used by Burn's `BinBytesRecorder`, but keep
-/// malformed/untrusted bytes on our fallible boundary instead of reaching the
-/// recorder's internal `unwrap()` in Burn 0.20.1.
+/// Decode the same bincode payload used by Burn's `BinBytesRecorder`, while
+/// keeping malformed or non-canonical bytes on our fallible boundary instead
+/// of reaching recorder/load_record panic paths in Burn 0.20.1.
 pub(crate) fn decode_bin_record<B, R>(
     data: &[u8],
     device: &B::Device,
@@ -13,9 +13,16 @@ where
     B: Backend,
     R: Record<B>,
 {
-    let (record, _consumed): (BurnRecord<R::Item<FullPrecisionSettings>, B>, usize) =
+    let (record, consumed): (BurnRecord<R::Item<FullPrecisionSettings>, B>, usize) =
         bincode::serde::decode_from_slice(data, bincode::config::standard())
             .map_err(|err| format!("{context}: invalid Burn bincode record: {err}"))?;
+
+    if consumed != data.len() {
+        return Err(format!(
+            "{context}: non-canonical Burn record: consumed {consumed} of {} bytes",
+            data.len()
+        ));
+    }
 
     Ok(R::from_item::<FullPrecisionSettings>(record.item, device))
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -265,11 +265,15 @@ impl LayerRegistry {
             LAYER_GHOST       => load_layer_state!(self, ghosts, layer_id, data),
             LAYER_SEBLOCK     => load_layer_state!(self, seblocks, layer_id, data),
             LAYER_POOL | LAYER_SHIFT | LAYER_BINARY => {
-                if self.layer_exists(layer_type, layer_id) {
-                    Ok(())
-                } else {
-                    Err("Not found".into())
+                if !self.layer_exists(layer_type, layer_id) {
+                    return Err("Not found".into());
                 }
+                if !data.is_empty() {
+                    return Err(format!(
+                        "loadLayerState: stateless layer type 0x{layer_type:02X} requires empty state"
+                    ));
+                }
+                Ok(())
             }
             _ => Err(format!("Unknown layer type for load_state: 0x{:02X}", layer_type)),
         }

--- a/src/stateless_lifecycle_tests.rs
+++ b/src/stateless_lifecycle_tests.rs
@@ -22,8 +22,9 @@ mod tests {
 
     fn assert_present_stateless_state(reg: &mut LayerRegistry, id: u32, layer_type: u8) {
         assert_eq!(reg.get_layer_state(id, layer_type).unwrap(), Vec::<u8>::new());
-        // Preserve the existing stateless contract: state bytes are ignored.
-        assert!(reg.load_layer_state(id, layer_type, &[9, 8, 7]).is_ok());
+        // Stateless state has one canonical encoding: empty bytes.
+        assert!(reg.load_layer_state(id, layer_type, &[9, 8, 7]).is_err());
+        assert!(reg.load_layer_state(id, layer_type, &[]).is_ok());
     }
 
     #[test]

--- a/tests/state_identity_conformance.rs
+++ b/tests/state_identity_conformance.rs
@@ -1,4 +1,9 @@
 use burn_research::agent::AgentLayerSpec;
+use burn_research::layers::activation::WasmActivation;
+use burn_research::layers::conv::WasmConv;
+use burn_research::layers::custom::ghost::WasmGhostModule;
+use burn_research::layers::custom::seblock::WasmSeBlock;
+use burn_research::layers::embedding::WasmEmbedding;
 use burn_research::layers::linear::WasmLinear;
 use burn_research::layers::norm::WasmNorm;
 use burn_research::protocol::{
@@ -224,4 +229,112 @@ fn valid_same_length_weight_mutation_preserves_structural_identity() {
     assert_eq!(registry.weight_layout(90, LAYER_LINEAR).unwrap(), layout_before);
     assert_eq!(registry.total_params(), params_before);
     assert_eq!(registry.get_weights_flat(90, LAYER_LINEAR).unwrap(), replacement);
+}
+
+#[test]
+fn direct_conv_rejects_cross_variant_state_without_panicking_or_mutating() {
+    let foreign = WasmConv::new_conv2d(3, 4, 3, 3, None, None, None, None);
+    let foreign_state = foreign.get_state().unwrap();
+    let mut target = WasmConv::new_conv1d(3, 4, 3, None, None);
+    let before = target.get_state().unwrap();
+    let params_before = target.num_params();
+
+    let call = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        target.load_state(&foreign_state)
+    }));
+    assert!(call.is_ok(), "foreign valid Conv record must not panic");
+    assert!(call.unwrap().is_err(), "Conv2d state must not load into Conv1d");
+    assert_eq!(target.get_state().unwrap(), before);
+    assert_eq!(target.num_params(), params_before);
+    target.load_state(&before).unwrap();
+}
+
+#[test]
+fn direct_conv_rejects_same_variant_shape_mismatch_without_mutating() {
+    let foreign = WasmConv::new_conv2d(5, 4, 3, 3, None, None, None, None);
+    let foreign_state = foreign.get_state().unwrap();
+    let mut target = WasmConv::new_conv2d(3, 4, 3, 3, None, None, None, None);
+    let before = target.get_state().unwrap();
+    let params_before = target.num_params();
+
+    assert!(target.load_state(&foreign_state).is_err());
+    assert_eq!(target.get_state().unwrap(), before);
+    assert_eq!(target.num_params(), params_before);
+    target.load_state(&before).unwrap();
+}
+
+#[test]
+fn direct_embedding_rejects_shape_mismatch_without_mutating() {
+    let foreign = WasmEmbedding::new(11, 4);
+    let foreign_state = foreign.get_state().unwrap();
+    let mut target = WasmEmbedding::new(10, 4);
+    let before = target.get_state().unwrap();
+    let dims_before = target.weight_dims();
+    let params_before = target.num_params();
+
+    assert!(target.load_state(&foreign_state).is_err());
+    assert_eq!(target.get_state().unwrap(), before);
+    assert_eq!(target.weight_dims(), dims_before);
+    assert_eq!(target.num_params(), params_before);
+    target.load_state(&before).unwrap();
+}
+
+#[test]
+fn direct_activation_rejects_cross_variant_state_without_panicking_or_mutating() {
+    let foreign = WasmActivation::new_relu();
+    let foreign_state = foreign.get_state().unwrap();
+    let mut target = WasmActivation::new_prelu(Some(3), None);
+    let before = target.get_state().unwrap();
+    let params_before = target.num_params();
+
+    let call = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        target.load_state(&foreign_state)
+    }));
+    assert!(call.is_ok(), "foreign valid Activation record must not panic");
+    assert!(call.unwrap().is_err(), "Relu state must not load into PRelu");
+    assert_eq!(target.get_state().unwrap(), before);
+    assert_eq!(target.num_params(), params_before);
+    target.load_state(&before).unwrap();
+}
+
+#[test]
+fn direct_activation_rejects_prelu_shape_mismatch_without_mutating() {
+    let foreign = WasmActivation::new_prelu(Some(4), None);
+    let foreign_state = foreign.get_state().unwrap();
+    let mut target = WasmActivation::new_prelu(Some(3), None);
+    let before = target.get_state().unwrap();
+    let params_before = target.num_params();
+
+    assert!(target.load_state(&foreign_state).is_err());
+    assert_eq!(target.get_state().unwrap(), before);
+    assert_eq!(target.num_params(), params_before);
+    target.load_state(&before).unwrap();
+}
+
+#[test]
+fn direct_ghost_rejects_structural_state_mismatch_without_mutating() {
+    let foreign = WasmGhostModule::new(6, 8, 3, 3, Some(2), None, None, None, None);
+    let foreign_state = foreign.get_state().unwrap();
+    let mut target = WasmGhostModule::new(4, 8, 3, 3, Some(2), None, None, None, None);
+    let before = target.get_state().unwrap();
+    let params_before = target.num_params();
+
+    assert!(target.load_state(&foreign_state).is_err());
+    assert_eq!(target.get_state().unwrap(), before);
+    assert_eq!(target.num_params(), params_before);
+    target.load_state(&before).unwrap();
+}
+
+#[test]
+fn direct_seblock_rejects_structural_state_mismatch_without_mutating() {
+    let foreign = WasmSeBlock::new(20, Some(4));
+    let foreign_state = foreign.get_state().unwrap();
+    let mut target = WasmSeBlock::new(16, Some(4));
+    let before = target.get_state().unwrap();
+    let params_before = target.num_params();
+
+    assert!(target.load_state(&foreign_state).is_err());
+    assert_eq!(target.get_state().unwrap(), before);
+    assert_eq!(target.num_params(), params_before);
+    target.load_state(&before).unwrap();
 }

--- a/tests/state_identity_conformance.rs
+++ b/tests/state_identity_conformance.rs
@@ -1,0 +1,156 @@
+use burn_research::agent::AgentLayerSpec;
+use burn_research::layers::linear::WasmLinear;
+use burn_research::protocol::{
+    LAYER_BINARY, LAYER_LINEAR, LAYER_POOL, LAYER_SHIFT,
+};
+use burn_research::registry::LayerRegistry;
+use burn_research::WasmTensor;
+
+#[test]
+fn cross_config_linear_state_load_must_not_change_structural_identity() {
+    let foreign = WasmLinear::new(4, 2, true);
+    let foreign_state = foreign.get_state().unwrap();
+
+    let spec = AgentLayerSpec::linear(70, 3, 2, true).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let fingerprint_before = registry
+        .layer_init_fingerprint(LAYER_LINEAR, 70)
+        .unwrap();
+    let state_before = registry.get_layer_state(70, LAYER_LINEAR).unwrap();
+    let layout_before = registry.weight_layout(70, LAYER_LINEAR).unwrap();
+    let params_before = registry.total_params();
+
+    let result = registry.load_layer_state(70, LAYER_LINEAR, &foreign_state);
+    assert!(
+        result.is_err(),
+        "state from Linear(4->2) must not load into a live Linear(3->2)"
+    );
+    assert_eq!(
+        registry.layer_init_fingerprint(LAYER_LINEAR, 70).unwrap(),
+        fingerprint_before,
+        "failed state load must preserve init identity"
+    );
+    assert_eq!(
+        registry.get_layer_state(70, LAYER_LINEAR).unwrap(),
+        state_before,
+        "failed cross-config load must preserve exact module state"
+    );
+    assert_eq!(
+        registry.weight_layout(70, LAYER_LINEAR).unwrap(),
+        layout_before,
+        "failed cross-config load must preserve parameter layout"
+    );
+    assert_eq!(registry.total_params(), params_before);
+
+    registry
+        .load_layer_state(70, LAYER_LINEAR, &state_before)
+        .unwrap();
+    let input = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
+    assert!(registry.forward_layer(70, LAYER_LINEAR, &input).is_ok());
+}
+
+#[test]
+fn same_config_linear_state_load_preserves_init_identity_and_structure() {
+    let source = WasmLinear::new(3, 2, true);
+    let source_state = source.get_state().unwrap();
+
+    let spec = AgentLayerSpec::linear(71, 3, 2, true).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let fingerprint_before = registry
+        .layer_init_fingerprint(LAYER_LINEAR, 71)
+        .unwrap();
+    let layout_before = registry.weight_layout(71, LAYER_LINEAR).unwrap();
+    let params_before = registry.total_params();
+
+    registry
+        .load_layer_state(71, LAYER_LINEAR, &source_state)
+        .unwrap();
+
+    assert_eq!(
+        registry.layer_init_fingerprint(LAYER_LINEAR, 71).unwrap(),
+        fingerprint_before
+    );
+    assert_eq!(registry.weight_layout(71, LAYER_LINEAR).unwrap(), layout_before);
+    assert_eq!(registry.total_params(), params_before);
+
+    let input = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
+    assert!(registry.forward_layer(71, LAYER_LINEAR, &input).is_ok());
+}
+
+#[test]
+fn stateless_layers_reject_nonempty_state_payload_and_accept_empty_state() {
+    let cases = vec![
+        (
+            AgentLayerSpec::max_pool1d(80, 2, None, None).unwrap(),
+            LAYER_POOL,
+        ),
+        (AgentLayerSpec::shift_up(81, 1), LAYER_SHIFT),
+        (AgentLayerSpec::add(82), LAYER_BINARY),
+    ];
+
+    let mut registry = LayerRegistry::new();
+    for (spec, layer_type) in cases {
+        registry.init_agent_layer(&spec).unwrap();
+        let layer_id = spec.layer_id();
+        let fingerprint_before = registry
+            .layer_init_fingerprint(layer_type, layer_id)
+            .unwrap();
+
+        assert_eq!(
+            registry.get_layer_state(layer_id, layer_type).unwrap(),
+            Vec::<u8>::new(),
+            "stateless layer must serialize as empty state"
+        );
+        assert!(
+            registry
+                .load_layer_state(layer_id, layer_type, &[1, 2, 3])
+                .is_err(),
+            "non-empty state must not be silently accepted for stateless type 0x{layer_type:02X}"
+        );
+        assert_eq!(
+            registry
+                .layer_init_fingerprint(layer_type, layer_id)
+                .unwrap(),
+            fingerprint_before
+        );
+        assert!(registry.layer_exists(layer_type, layer_id));
+        registry
+            .load_layer_state(layer_id, layer_type, &[])
+            .unwrap();
+    }
+}
+
+#[test]
+fn valid_same_length_weight_mutation_preserves_structural_identity() {
+    let spec = AgentLayerSpec::linear(90, 3, 2, true).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let fingerprint_before = registry
+        .layer_init_fingerprint(LAYER_LINEAR, 90)
+        .unwrap();
+    let layout_before = registry.weight_layout(90, LAYER_LINEAR).unwrap();
+    let params_before = registry.total_params();
+    let weights_before = registry.get_weights_flat(90, LAYER_LINEAR).unwrap();
+    let replacement = weights_before
+        .iter()
+        .enumerate()
+        .map(|(index, value)| value + (index as f32 + 1.0) * 0.01)
+        .collect::<Vec<_>>();
+
+    registry
+        .set_weights_flat(90, LAYER_LINEAR, &replacement)
+        .unwrap();
+
+    assert_eq!(
+        registry.layer_init_fingerprint(LAYER_LINEAR, 90).unwrap(),
+        fingerprint_before
+    );
+    assert_eq!(registry.weight_layout(90, LAYER_LINEAR).unwrap(), layout_before);
+    assert_eq!(registry.total_params(), params_before);
+    assert_eq!(registry.get_weights_flat(90, LAYER_LINEAR).unwrap(), replacement);
+}

--- a/tests/state_identity_conformance.rs
+++ b/tests/state_identity_conformance.rs
@@ -1,7 +1,8 @@
 use burn_research::agent::AgentLayerSpec;
 use burn_research::layers::linear::WasmLinear;
+use burn_research::layers::norm::WasmNorm;
 use burn_research::protocol::{
-    LAYER_BINARY, LAYER_LINEAR, LAYER_POOL, LAYER_SHIFT,
+    LAYER_BINARY, LAYER_LINEAR, LAYER_NORM, LAYER_POOL, LAYER_SHIFT,
 };
 use burn_research::registry::LayerRegistry;
 use burn_research::WasmTensor;
@@ -79,6 +80,76 @@ fn same_config_linear_state_load_preserves_init_identity_and_structure() {
 
     let input = WasmTensor::new(&[1.0, 2.0, 3.0], &[1, 3, 1, 1]);
     assert!(registry.forward_layer(71, LAYER_LINEAR, &input).is_ok());
+}
+
+#[test]
+fn cross_variant_norm_state_must_fail_closed_without_panicking_or_mutating() {
+    let foreign = WasmNorm::new_batch_norm(2, None);
+    let foreign_state = foreign.get_state().unwrap();
+
+    let spec = AgentLayerSpec::layer_norm(72, 2, None).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let fingerprint_before = registry.layer_init_fingerprint(LAYER_NORM, 72).unwrap();
+    let state_before = registry.get_layer_state(72, LAYER_NORM).unwrap();
+    let layout_before = registry.weight_layout(72, LAYER_NORM).unwrap();
+    let params_before = registry.total_params();
+
+    let call = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        registry.load_layer_state(72, LAYER_NORM, &foreign_state)
+    }));
+    assert!(call.is_ok(), "foreign valid Norm record must not panic");
+    assert!(
+        call.unwrap().is_err(),
+        "BatchNorm state must not load into a live LayerNorm"
+    );
+    assert_eq!(
+        registry.layer_init_fingerprint(LAYER_NORM, 72).unwrap(),
+        fingerprint_before
+    );
+    assert_eq!(registry.get_layer_state(72, LAYER_NORM).unwrap(), state_before);
+    assert_eq!(registry.weight_layout(72, LAYER_NORM).unwrap(), layout_before);
+    assert_eq!(registry.total_params(), params_before);
+
+    registry
+        .load_layer_state(72, LAYER_NORM, &state_before)
+        .unwrap();
+}
+
+#[test]
+fn state_decoder_rejects_trailing_bytes_without_mutating_live_layer() {
+    let spec = AgentLayerSpec::linear(73, 3, 2, true).unwrap();
+    let mut registry = LayerRegistry::new();
+    registry.init_agent_layer(&spec).unwrap();
+
+    let fingerprint_before = registry
+        .layer_init_fingerprint(LAYER_LINEAR, 73)
+        .unwrap();
+    let state_before = registry.get_layer_state(73, LAYER_LINEAR).unwrap();
+    let layout_before = registry.weight_layout(73, LAYER_LINEAR).unwrap();
+    let params_before = registry.total_params();
+
+    let mut tainted = state_before.clone();
+    tainted.extend_from_slice(&[0xAA, 0x55, 0x01]);
+
+    assert!(
+        registry
+            .load_layer_state(73, LAYER_LINEAR, &tainted)
+            .is_err(),
+        "a canonical Burn state followed by trailing bytes must be rejected"
+    );
+    assert_eq!(
+        registry.layer_init_fingerprint(LAYER_LINEAR, 73).unwrap(),
+        fingerprint_before
+    );
+    assert_eq!(registry.get_layer_state(73, LAYER_LINEAR).unwrap(), state_before);
+    assert_eq!(registry.weight_layout(73, LAYER_LINEAR).unwrap(), layout_before);
+    assert_eq!(registry.total_params(), params_before);
+
+    registry
+        .load_layer_state(73, LAYER_LINEAR, &state_before)
+        .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Advances #62 as part of end-to-end audit #45.

Tests-first only; no production changes in this initial commit.

The integration proofs ask four questions:
- can a valid Burn Linear record from a structurally different configuration be loaded into an existing Registry layer and desynchronize live execution shape from the original init fingerprint?
- does same-config state loading remain valid while preserving init identity/layout/parameter count?
- do stateless Pool/Shift/Binary layers reject non-empty state blobs instead of silently reporting successful restore?
- does valid same-length `setWeightsFlat` preserve structural identity/layout/parameter count?

A failing CI result is expected if either suspected mutation/provenance gap is real. Production remediation should follow evidence, not precede it.