### PR TITLE
Audit canonical Workspace layout preflight

### DIFF
--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -63,21 +63,21 @@ impl LayoutCompatibility {
     }
 }
 
-fn layout_profile(spec: &AgentLayerSpec) -> LayoutProfile {
+fn layout_profile_for(layer_type: u8, variant: u8) -> LayoutProfile {
     let input_output = |layout| LayoutProfile {
         input: layout,
         output: layout,
     };
 
-    match spec.layer_type() {
+    match layer_type {
         LAYER_LINEAR => input_output(LayoutTag::FeatureAxis1Singleton),
-        LAYER_NORM => match spec.variant() {
+        LAYER_NORM => match variant {
             NORM_BATCH | NORM_GROUP | NORM_INSTANCE => input_output(LayoutTag::ChannelFirst),
             NORM_LAYER | NORM_RMS => input_output(LayoutTag::FeatureLast),
             _ => input_output(LayoutTag::Dynamic),
         },
         LAYER_CONV => {
-            if spec.variant() == CONV_CONV1D {
+            if variant == CONV_CONV1D {
                 input_output(LayoutTag::ChannelFirstSingletonWidth)
             } else {
                 input_output(LayoutTag::ChannelFirst)
@@ -88,14 +88,14 @@ fn layout_profile(spec: &AgentLayerSpec) -> LayoutProfile {
             output: LayoutTag::SequenceFeatureAxis2SingletonWidth,
         },
         LAYER_POOL => {
-            if matches!(spec.variant(), POOL_MAXPOOL1D | POOL_AVGPOOL1D) {
+            if matches!(variant, POOL_MAXPOOL1D | POOL_AVGPOOL1D) {
                 input_output(LayoutTag::ChannelFirstSingletonWidth)
             } else {
                 input_output(LayoutTag::ChannelFirst)
             }
         }
         LAYER_SHIFT | LAYER_GHOST | LAYER_SEBLOCK => input_output(LayoutTag::ChannelFirst),
-        LAYER_ACTIVATION => match spec.variant() {
+        LAYER_ACTIVATION => match variant {
             ACT_SWIGLU => input_output(LayoutTag::FeatureLast),
             ACT_PRELU => LayoutProfile {
                 input: LayoutTag::Dynamic,
@@ -109,6 +109,10 @@ fn layout_profile(spec: &AgentLayerSpec) -> LayoutProfile {
         LAYER_BINARY => input_output(LayoutTag::Dynamic),
         _ => input_output(LayoutTag::Dynamic),
     }
+}
+
+fn layout_profile(spec: &AgentLayerSpec) -> LayoutProfile {
+    layout_profile_for(spec.layer_type(), spec.variant())
 }
 
 fn compatibility(producer_output: LayoutTag, consumer_input: LayoutTag) -> LayoutCompatibility {
@@ -138,6 +142,32 @@ fn compatibility(producer_output: LayoutTag, consumer_input: LayoutTag) -> Layou
         | (ChannelFirstSingletonWidth, FeatureAxis1Singleton) => Unknown,
         _ => Incompatible,
     }
+}
+
+fn validate_layout_profiles(
+    producer_profile: LayoutProfile,
+    consumer_profile: LayoutProfile,
+) -> Result<(), String> {
+    let result = compatibility(producer_profile.output, consumer_profile.input);
+    if result == LayoutCompatibility::Incompatible {
+        return Err(format!(
+            "validateAgentLayoutEdge: producer output layout {} is incompatible with consumer input layout {}; implicit relayout is forbidden",
+            producer_profile.output.as_str(),
+            consumer_profile.input.as_str()
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_agent_layout_identity_edge(
+    producer_layer_type: u8,
+    producer_variant: u8,
+    consumer: &AgentLayerSpec,
+) -> Result<(), String> {
+    validate_layout_profiles(
+        layout_profile_for(producer_layer_type, producer_variant),
+        layout_profile(consumer),
+    )
 }
 
 /// Return the canonical machine-readable contract manifest used by agents and future fuzzers.
@@ -195,17 +225,7 @@ pub fn validate_agent_layout_edge(
     producer: &AgentLayerSpec,
     consumer: &AgentLayerSpec,
 ) -> Result<(), String> {
-    let producer_profile = layout_profile(producer);
-    let consumer_profile = layout_profile(consumer);
-    let result = compatibility(producer_profile.output, consumer_profile.input);
-    if result == LayoutCompatibility::Incompatible {
-        return Err(format!(
-            "validateAgentLayoutEdge: producer output layout {} is incompatible with consumer input layout {}; implicit relayout is forbidden",
-            producer_profile.output.as_str(),
-            consumer_profile.input.as_str()
-        ));
-    }
-    Ok(())
+    validate_layout_profiles(layout_profile(producer), layout_profile(consumer))
 }
 
 #[cfg(test)]

--- a/src/workspace_ops.rs
+++ b/src/workspace_ops.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::agent::{AgentGraphBuilder, AgentLayerSpec};
+use crate::contracts::validate_agent_layout_identity_edge;
 use crate::graph::CompiledGraph;
 use crate::protocol::LAYER_BINARY;
 use crate::registry::LayerRegistry;
@@ -30,6 +31,82 @@ fn validate_workspace_input_slot(
 ) -> Result<(), String> {
     validate_builder_slot(builder, slot, context)?;
     workspace.ensure_slot_readable(slot, context)
+}
+
+fn workspace_row_value(row: &str) -> Option<&str> {
+    const PREFIX: &str = "\"value\":\"";
+    let start = row.rfind(PREFIX)? + PREFIX.len();
+    let tail = &row[start..];
+    let end = tail.rfind("\"}")?;
+    Some(&tail[..end])
+}
+
+fn workspace_slot_producer_identity(
+    workspace: &AgentWorkspace,
+    slot: u8,
+    context: &str,
+) -> Result<Option<(u8, u8)>, String> {
+    let slot_row = workspace.get("_slots".into(), slot.to_string());
+    let Some(owner) = workspace_row_value(&slot_row) else {
+        return Err(format!(
+            "{context}: internal slot {slot} row is missing a value field"
+        ));
+    };
+    let Some(layer_id) = owner.strip_prefix("layer:") else {
+        return Ok(None);
+    };
+    let layer_id = layer_id.parse::<u32>().map_err(|_| {
+        format!("{context}: internal slot {slot} has invalid layer owner {owner}")
+    })?;
+
+    let layer_row = workspace.get("_layers".into(), layer_id.to_string());
+    if layer_row == "null" {
+        return Err(format!(
+            "{context}: internal slot {slot} references missing layer metadata id {layer_id}"
+        ));
+    }
+    let layer_value = workspace_row_value(&layer_row).ok_or_else(|| {
+        format!(
+            "{context}: internal layer metadata id {layer_id} is missing a value field"
+        )
+    })?;
+    let (before_variant, variant) = layer_value.rsplit_once(";variant=").ok_or_else(|| {
+        format!(
+            "{context}: internal layer metadata id {layer_id} is missing variant provenance"
+        )
+    })?;
+    let (_, layer_type) = before_variant.rsplit_once(";type=").ok_or_else(|| {
+        format!(
+            "{context}: internal layer metadata id {layer_id} is missing type provenance"
+        )
+    })?;
+    let layer_type = layer_type.parse::<u8>().map_err(|_| {
+        format!(
+            "{context}: internal layer metadata id {layer_id} has invalid type provenance"
+        )
+    })?;
+    let variant = variant.parse::<u8>().map_err(|_| {
+        format!(
+            "{context}: internal layer metadata id {layer_id} has invalid variant provenance"
+        )
+    })?;
+    Ok(Some((layer_type, variant)))
+}
+
+fn validate_workspace_layout_input(
+    workspace: &AgentWorkspace,
+    slot: u8,
+    consumer: &AgentLayerSpec,
+    context: &str,
+) -> Result<(), String> {
+    let Some((producer_layer_type, producer_variant)) =
+        workspace_slot_producer_identity(workspace, slot, context)?
+    else {
+        return Ok(());
+    };
+
+    validate_agent_layout_identity_edge(producer_layer_type, producer_variant, consumer)
+        .map_err(|err| format!("{context}: {err}"))
 }
 
 fn validate_spec_is_new(
@@ -252,9 +329,10 @@ pub fn workspace_capabilities() -> String {
         "\"ownership\":\"metadata_only\",",
         "\"execution_truth\":\"LayerRegistry\",",
         "\"graph\":\"AgentGraphBuilder\",",
-        "\"provenance\":{\"wire_identity\":\"exact_validated_init_fingerprint\",\"syncLayer\":\"exact_identity_metadata_only_not_canonical_orchestration\"},",
+        "\"provenance\":{\"wire_identity\":\"exact_validated_init_fingerprint\",\"syncLayer\":\"exact_identity_metadata_only_not_canonical_orchestration\",\"layout_preflight\":\"canonical_slot_owner_to_layer_type_variant\"},",
         "\"atomicity\":{\"compile\":\"non_mutating_output_override\",\"workspace_init\":\"transactional_post_registry_rollback\"},",
         "\"slot_lifecycle\":{\"states\":[\"input\",\"free\",\"reserved\"],\"readable\":[\"input\",\"reserved\"],\"reserve\":\"free->reserved\",\"release\":\"reserved->free\",\"invalid_transition\":\"error_no_mutation\"},",
+        "\"layout_policy\":{\"known_incompatible\":\"reject_before_mutation\",\"unknown\":\"defer_to_runtime\",\"implicit_relayout\":\"forbidden\"},",
         "\"ops\":[\"workspaceInitUnary\",\"workspaceInitBinary\",\"workspaceWireUnary\",\"workspaceWireBinary\",\"workspaceCompile\"],",
         "\"workspace_methods\":[\"reserveLayerId\",\"reserveSlot\",\"releaseSlot\",\"syncLayer\",\"forgetLayer\",\"recordProof\",\"recordEvent\",\"put\",\"get\",\"query\",\"remove\",\"tableNames\",\"snapshot\",\"limits\"],",
         "\"escape_hatches\":[\"AgentLayerSpec\",\"AgentGraphBuilder\",\"LayerRegistry\",\"raw_protocol\"],",
@@ -279,6 +357,7 @@ pub fn workspace_wire_unary(
         return Err("workspaceWireUnary: binary spec requires workspaceWireBinary".into());
     }
     validate_workspace_input_slot(workspace, builder, input_slot, "workspaceWireUnary")?;
+    validate_workspace_layout_input(workspace, input_slot, spec, "workspaceWireUnary")?;
     ensure_registry_matches_spec(registry, spec, "workspaceWireUnary")?;
     validate_workspace_op_label(&label, "workspaceWireUnary")?;
 
@@ -317,6 +396,8 @@ pub fn workspace_wire_binary(
     }
     validate_workspace_input_slot(workspace, builder, left_slot, "workspaceWireBinary.left")?;
     validate_workspace_input_slot(workspace, builder, right_slot, "workspaceWireBinary.right")?;
+    validate_workspace_layout_input(workspace, left_slot, spec, "workspaceWireBinary.left")?;
+    validate_workspace_layout_input(workspace, right_slot, spec, "workspaceWireBinary.right")?;
     ensure_registry_matches_spec(registry, spec, "workspaceWireBinary")?;
     validate_workspace_op_label(&label, "workspaceWireBinary")?;
 
@@ -352,6 +433,7 @@ pub fn workspace_init_unary(
         return Err("workspaceInitUnary: binary spec requires workspaceInitBinary".into());
     }
     validate_workspace_input_slot(workspace, builder, input_slot, "workspaceInitUnary")?;
+    validate_workspace_layout_input(workspace, input_slot, spec, "workspaceInitUnary")?;
     validate_spec_is_new(registry, spec, "workspaceInitUnary")?;
     ensure_workspace_layer_reserved(workspace, spec, "workspaceInitUnary")?;
     validate_workspace_op_label(&label, "workspaceInitUnary")?;
@@ -410,6 +492,8 @@ pub fn workspace_init_binary(
     }
     validate_workspace_input_slot(workspace, builder, left_slot, "workspaceInitBinary.left")?;
     validate_workspace_input_slot(workspace, builder, right_slot, "workspaceInitBinary.right")?;
+    validate_workspace_layout_input(workspace, left_slot, spec, "workspaceInitBinary.left")?;
+    validate_workspace_layout_input(workspace, right_slot, spec, "workspaceInitBinary.right")?;
     validate_spec_is_new(registry, spec, "workspaceInitBinary")?;
     ensure_workspace_layer_reserved(workspace, spec, "workspaceInitBinary")?;
     validate_workspace_op_label(&label, "workspaceInitBinary")?;

--- a/tests/workspace_layout_preflight.rs
+++ b/tests/workspace_layout_preflight.rs
@@ -1,0 +1,157 @@
+use burn_research::agent::{AgentGraphBuilder, AgentLayerSpec};
+use burn_research::protocol::LAYER_NORM;
+use burn_research::registry::LayerRegistry;
+use burn_research::workspace::AgentWorkspace;
+use burn_research::workspace_ops::{
+    workspace_compile, workspace_init_unary, workspace_wire_unary,
+};
+use burn_research::WasmTensor;
+
+#[test]
+fn canonical_init_rejects_known_layout_mismatch_before_mutation() {
+    let mut workspace = AgentWorkspace::new(4).unwrap();
+    let mut registry = LayerRegistry::new();
+    let mut builder = AgentGraphBuilder::new(4).unwrap();
+
+    let linear_id = workspace.reserve_layer_id(&registry, "linear".into()).unwrap();
+    let linear = AgentLayerSpec::linear(linear_id, 4, 4, true).unwrap();
+    let linear_out = workspace_init_unary(
+        &mut workspace,
+        &mut builder,
+        &mut registry,
+        &linear,
+        0,
+        "linear".into(),
+    )
+    .unwrap();
+
+    let norm_id = workspace.reserve_layer_id(&registry, "layernorm".into()).unwrap();
+    let layer_norm = AgentLayerSpec::layer_norm(norm_id, 4, None).unwrap();
+    let before = workspace.snapshot();
+    let steps_before = builder.num_steps();
+
+    let err = workspace_init_unary(
+        &mut workspace,
+        &mut builder,
+        &mut registry,
+        &layer_norm,
+        linear_out,
+        "layernorm".into(),
+    )
+    .expect_err("known Linear -> LayerNorm layout mismatch must fail before execution");
+
+    assert!(err.contains("layout"), "unexpected error: {err}");
+    assert_eq!(workspace.snapshot(), before);
+    assert_eq!(builder.num_steps(), steps_before);
+    assert!(!registry.layer_exists(LAYER_NORM, norm_id));
+}
+
+#[test]
+fn canonical_wire_rejects_known_layout_mismatch_without_metadata_or_slot_mutation() {
+    let mut workspace = AgentWorkspace::new(4).unwrap();
+    let mut registry = LayerRegistry::new();
+    let mut builder = AgentGraphBuilder::new(4).unwrap();
+
+    let linear_id = workspace.reserve_layer_id(&registry, "linear".into()).unwrap();
+    let linear = AgentLayerSpec::linear(linear_id, 4, 4, true).unwrap();
+    let linear_out = workspace_init_unary(
+        &mut workspace,
+        &mut builder,
+        &mut registry,
+        &linear,
+        0,
+        "linear".into(),
+    )
+    .unwrap();
+
+    let layer_norm = AgentLayerSpec::layer_norm(99, 4, None).unwrap();
+    registry.init_agent_layer(&layer_norm).unwrap();
+    let before = workspace.snapshot();
+    let steps_before = builder.num_steps();
+
+    let err = workspace_wire_unary(
+        &mut workspace,
+        &mut builder,
+        &registry,
+        &layer_norm,
+        linear_out,
+        "manual-layernorm".into(),
+    )
+    .expect_err("known Linear -> LayerNorm layout mismatch must fail before wire mutation");
+
+    assert!(err.contains("layout"), "unexpected error: {err}");
+    assert_eq!(workspace.snapshot(), before);
+    assert_eq!(builder.num_steps(), steps_before);
+    assert_eq!(workspace.get("_layers".into(), "99".into()), "null");
+}
+
+#[test]
+fn unknown_preserve_layout_still_defers_to_runtime() {
+    let mut workspace = AgentWorkspace::new(4).unwrap();
+    let mut registry = LayerRegistry::new();
+    let mut builder = AgentGraphBuilder::new(4).unwrap();
+
+    let relu_id = workspace.reserve_layer_id(&registry, "relu".into()).unwrap();
+    let relu = AgentLayerSpec::relu(relu_id);
+    let relu_out = workspace_init_unary(
+        &mut workspace,
+        &mut builder,
+        &mut registry,
+        &relu,
+        0,
+        "relu".into(),
+    )
+    .unwrap();
+
+    let norm_id = workspace.reserve_layer_id(&registry, "layernorm".into()).unwrap();
+    let layer_norm = AgentLayerSpec::layer_norm(norm_id, 4, None).unwrap();
+    let out = workspace_init_unary(
+        &mut workspace,
+        &mut builder,
+        &mut registry,
+        &layer_norm,
+        relu_out,
+        "layernorm".into(),
+    )
+    .expect("preserve/unknown producer layout must defer rather than overclaim incompatibility");
+
+    assert_eq!(builder.num_steps(), 2);
+    assert!(registry.layer_exists(LAYER_NORM, norm_id));
+    assert_eq!(out, 2);
+}
+
+#[test]
+fn known_compatible_linear_to_batchnorm_remains_executable() {
+    let mut workspace = AgentWorkspace::new(4).unwrap();
+    let mut registry = LayerRegistry::new();
+    let mut builder = AgentGraphBuilder::new(4).unwrap();
+
+    let linear_id = workspace.reserve_layer_id(&registry, "linear".into()).unwrap();
+    let linear = AgentLayerSpec::linear(linear_id, 4, 4, true).unwrap();
+    let linear_out = workspace_init_unary(
+        &mut workspace,
+        &mut builder,
+        &mut registry,
+        &linear,
+        0,
+        "linear".into(),
+    )
+    .unwrap();
+
+    let norm_id = workspace.reserve_layer_id(&registry, "batchnorm".into()).unwrap();
+    let batch_norm = AgentLayerSpec::batch_norm(norm_id, 4, None).unwrap();
+    let out = workspace_init_unary(
+        &mut workspace,
+        &mut builder,
+        &mut registry,
+        &batch_norm,
+        linear_out,
+        "batchnorm".into(),
+    )
+    .unwrap();
+
+    let graph = workspace_compile(&builder, &registry, out).unwrap();
+    let input = WasmTensor::new(&[1.0, 2.0, 3.0, 4.0], &[1, 4, 1, 1]);
+    let output = graph.run(&registry, &input).unwrap();
+    assert_eq!(output.shape(), vec![1, 4, 1, 1]);
+}


### PR DESCRIPTION
Closes #64 as final remediation work for audit checkpoint #45.

This PR proved and fixed the Level-4 canonical Workspace layout preflight gap:
- known Linear -> LayerNorm mismatch rejects before Registry/Workspace/Builder mutation
- manual/rejoined wire obeys the same known mismatch rule
- preserve/unknown producer layout continues to defer to Burn/runtime
- known-compatible Linear -> BatchNorm remains executable
- Level 1/2/3 escape hatches remain unchanged

Follow-up aggregation audit #45 found one remaining schema/matrix bookkeeping gap after merge: the runtime/discovery policy is enforced, but docs/agent-contracts.v1.json does not yet declare the layout precondition, so the schema-generated negative matrix cannot generate that cell. Issue #64 is being reopened for that final schema/matrix alignment.