### PR TITLE
Run packaged WASM artifact audit in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Audit packaged WASM surface
         run: python3 scripts/check_wasm_surface.py
 
+      - name: Run packaged WASM artifact audit
+        run: node scripts/audit_wasm_artifact.mjs pkg
+
       - name: Run host tests
         run: cargo test --lib --tests
 


### PR DESCRIPTION
Closes #73.

Adds one CI gate after `Audit packaged WASM surface`:

```sh
node scripts/audit_wasm_artifact.mjs pkg
```

This turns the merged audit-v5 harness into an executable packaged-artifact regression gate.

Expected baseline:
- 15/15 required artifact checks PASS
- verdict `PASS_WITH_KNOWN_LIMITATIONS`
- the existing default async local `file://` loader caveat remains informational and does not fail CI
- any unexpected required audit failure exits non-zero and fails the workflow

No runtime, contract, optimizer, or PGAAS policy changes.