### PR TITLE
Package official Node host adapter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           python3 -m json.tool docs/agent-contracts.v1.json >/dev/null
           python3 -m json.tool docs/wasm-surface.v1.json >/dev/null
+          python3 -m json.tool docs/host-support.v1.json >/dev/null
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -76,11 +77,17 @@ jobs:
       - name: Build WASM
         run: wasm-pack build --target web --out-dir pkg
 
+      - name: Package Node host adapter
+        run: node scripts/package_node_host.mjs pkg
+
       - name: Audit packaged WASM surface
         run: python3 scripts/check_wasm_surface.py
 
       - name: Run packaged WASM artifact audit
         run: node scripts/audit_wasm_artifact.mjs pkg
+
+      - name: Run Node host adapter audit
+        run: node scripts/audit_node_host.mjs pkg
 
       - name: Run host tests
         run: cargo test --lib --tests

--- a/docs/host-support.v1.json
+++ b/docs/host-support.v1.json
@@ -1,0 +1,25 @@
+{
+  "schema": "burn-research.host-support.v1",
+  "artifact_target": "wasm-bindgen-web",
+  "verified_hosts": {
+    "node": {
+      "status": "supported",
+      "module_system": "esm",
+      "adapter": "node.mjs",
+      "initialization": "filesystem_read_plus_initSync",
+      "local_file_package": true,
+      "ci_smoke_required": true
+    }
+  },
+  "generated_but_not_host_verified": {
+    "browser": {
+      "entry": "burn_research.js",
+      "initialization": "wasm-bindgen_default_async"
+    }
+  },
+  "planned_hosts": [
+    "rust",
+    "python",
+    "go"
+  ]
+}

--- a/docs/host-support.v1.json
+++ b/docs/host-support.v1.json
@@ -6,6 +6,7 @@
       "status": "supported",
       "module_system": "esm",
       "adapter": "node.mjs",
+      "types": "node.d.mts",
       "initialization": "filesystem_read_plus_initSync",
       "local_file_package": true,
       "ci_smoke_required": true

--- a/hosts/node/node.d.mts
+++ b/hosts/node/node.d.mts
@@ -1,0 +1,5 @@
+export declare function loadBurnRuntime(
+  packageDir?: string | URL,
+): Promise<typeof import('./burn_research.js')>;
+
+export declare function burnRuntimePackageDir(): string;

--- a/hosts/node/node.mjs
+++ b/hosts/node/node.mjs
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const DEFAULT_PACKAGE_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+function resolvePackageDir(packageDir) {
+  if (packageDir === undefined || packageDir === null) {
+    return DEFAULT_PACKAGE_DIR;
+  }
+  if (packageDir instanceof URL) {
+    if (packageDir.protocol !== 'file:') {
+      throw new TypeError(`Node host adapter requires a file: URL, got ${packageDir.protocol}`);
+    }
+    return fileURLToPath(packageDir);
+  }
+  return path.resolve(String(packageDir));
+}
+
+/**
+ * Load the packaged Burn/WASM runtime from a local filesystem directory.
+ *
+ * This is the supported Node path for the wasm-pack `web` artifact. It avoids
+ * default async `file://` fetch semantics by reading the sibling WASM bytes and
+ * passing them to wasm-bindgen's synchronous initializer.
+ */
+export async function loadBurnRuntime(packageDir = DEFAULT_PACKAGE_DIR) {
+  const dir = resolvePackageDir(packageDir);
+  const jsPath = path.join(dir, 'burn_research.js');
+  const wasmPath = path.join(dir, 'burn_research_bg.wasm');
+
+  const [runtime, wasmBytes] = await Promise.all([
+    import(pathToFileURL(jsPath).href),
+    fs.promises.readFile(wasmPath),
+  ]);
+
+  runtime.initSync({ module: wasmBytes });
+  return runtime;
+}
+
+export function burnRuntimePackageDir() {
+  return DEFAULT_PACKAGE_DIR;
+}

--- a/scripts/audit_node_host.mjs
+++ b/scripts/audit_node_host.mjs
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const pkgDir = path.resolve(process.argv[2] ?? 'pkg');
+const adapterPath = path.join(pkgDir, 'node.mjs');
+const supportPath = path.join(pkgDir, 'host-support.v1.json');
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+assert(fs.existsSync(adapterPath), 'packaged node.mjs is missing');
+assert(fs.existsSync(supportPath), 'packaged host-support.v1.json is missing');
+
+const support = JSON.parse(fs.readFileSync(supportPath, 'utf8'));
+assert(support.schema === 'burn-research.host-support.v1', 'host support schema mismatch');
+assert(support.verified_hosts?.node?.status === 'supported', 'Node host must be declared supported');
+assert(support.verified_hosts?.node?.adapter === 'node.mjs', 'Node adapter discovery mismatch');
+
+const adapter = await import(pathToFileURL(adapterPath).href);
+const runtime = await adapter.loadBurnRuntime();
+
+const programCaps = JSON.parse(runtime.programCapabilities());
+const bundleCaps = JSON.parse(runtime.programBundleCapabilities());
+assert(programCaps.execution_binding === 'required', 'program execution binding capability mismatch');
+assert(bundleCaps.schema === 'burn-research.program-bundle.v1', 'program bundle capability mismatch');
+
+const reg = new runtime.LayerRegistry();
+const spec = runtime.AgentLayerSpec.relu(1);
+reg.initAgentLayer(spec);
+const builder = new runtime.AgentGraphBuilder(2);
+builder.addUnary(spec, 0, 1);
+builder.setOutput(1);
+const graph = builder.compile(reg);
+const input = new runtime.WasmTensor(
+  new Float32Array([-2, 3]),
+  new Uint32Array([1, 2, 1, 1]),
+);
+const output = graph.run(reg, input);
+const got = Array.from(output.to_array());
+assert(got.length === 2 && got[0] === 0 && got[1] === 3, `Node host execution mismatch: ${got}`);
+
+output.free();
+input.free();
+graph.free();
+builder.free();
+spec.free();
+reg.free();
+
+console.log(JSON.stringify({
+  verdict: 'PASS',
+  host: 'node',
+  adapter: 'node.mjs',
+  packageDir: adapter.burnRuntimePackageDir(),
+  execution: got,
+  programIdentitySchema: programCaps.identity_schema,
+  programBundleSchema: bundleCaps.schema,
+}, null, 2));

--- a/scripts/audit_node_host.mjs
+++ b/scripts/audit_node_host.mjs
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'node:url';
 
 const pkgDir = path.resolve(process.argv[2] ?? 'pkg');
 const adapterPath = path.join(pkgDir, 'node.mjs');
+const typesPath = path.join(pkgDir, 'node.d.mts');
 const supportPath = path.join(pkgDir, 'host-support.v1.json');
 
 function assert(condition, message) {
@@ -11,12 +12,14 @@ function assert(condition, message) {
 }
 
 assert(fs.existsSync(adapterPath), 'packaged node.mjs is missing');
+assert(fs.existsSync(typesPath), 'packaged node.d.mts is missing');
 assert(fs.existsSync(supportPath), 'packaged host-support.v1.json is missing');
 
 const support = JSON.parse(fs.readFileSync(supportPath, 'utf8'));
 assert(support.schema === 'burn-research.host-support.v1', 'host support schema mismatch');
 assert(support.verified_hosts?.node?.status === 'supported', 'Node host must be declared supported');
 assert(support.verified_hosts?.node?.adapter === 'node.mjs', 'Node adapter discovery mismatch');
+assert(support.verified_hosts?.node?.types === 'node.d.mts', 'Node type discovery mismatch');
 
 const adapter = await import(pathToFileURL(adapterPath).href);
 const runtime = await adapter.loadBurnRuntime();
@@ -52,6 +55,7 @@ console.log(JSON.stringify({
   verdict: 'PASS',
   host: 'node',
   adapter: 'node.mjs',
+  types: 'node.d.mts',
   packageDir: adapter.burnRuntimePackageDir(),
   execution: got,
   programIdentitySchema: programCaps.identity_schema,

--- a/scripts/package_node_host.mjs
+++ b/scripts/package_node_host.mjs
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const pkgDir = path.resolve(process.argv[2] ?? 'pkg');
+const packageJsonPath = path.join(pkgDir, 'package.json');
+const nodeAdapterSource = path.resolve('hosts/node/node.mjs');
+const hostSupportSource = path.resolve('docs/host-support.v1.json');
+const nodeAdapterTarget = path.join(pkgDir, 'node.mjs');
+const hostSupportTarget = path.join(pkgDir, 'host-support.v1.json');
+
+if (!fs.existsSync(packageJsonPath)) {
+  throw new Error(`package.json not found in ${pkgDir}`);
+}
+
+fs.copyFileSync(nodeAdapterSource, nodeAdapterTarget);
+fs.copyFileSync(hostSupportSource, hostSupportTarget);
+
+const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const files = Array.isArray(manifest.files) ? [...manifest.files] : [];
+for (const file of ['node.mjs', 'host-support.v1.json']) {
+  if (!files.includes(file)) files.push(file);
+}
+manifest.files = files;
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+console.log(JSON.stringify({
+  packaged: true,
+  pkgDir,
+  files: ['node.mjs', 'host-support.v1.json'],
+}, null, 2));

--- a/scripts/package_node_host.mjs
+++ b/scripts/package_node_host.mjs
@@ -4,8 +4,10 @@ import path from 'node:path';
 const pkgDir = path.resolve(process.argv[2] ?? 'pkg');
 const packageJsonPath = path.join(pkgDir, 'package.json');
 const nodeAdapterSource = path.resolve('hosts/node/node.mjs');
+const nodeTypesSource = path.resolve('hosts/node/node.d.mts');
 const hostSupportSource = path.resolve('docs/host-support.v1.json');
 const nodeAdapterTarget = path.join(pkgDir, 'node.mjs');
+const nodeTypesTarget = path.join(pkgDir, 'node.d.mts');
 const hostSupportTarget = path.join(pkgDir, 'host-support.v1.json');
 
 if (!fs.existsSync(packageJsonPath)) {
@@ -13,11 +15,12 @@ if (!fs.existsSync(packageJsonPath)) {
 }
 
 fs.copyFileSync(nodeAdapterSource, nodeAdapterTarget);
+fs.copyFileSync(nodeTypesSource, nodeTypesTarget);
 fs.copyFileSync(hostSupportSource, hostSupportTarget);
 
 const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 const files = Array.isArray(manifest.files) ? [...manifest.files] : [];
-for (const file of ['node.mjs', 'host-support.v1.json']) {
+for (const file of ['node.mjs', 'node.d.mts', 'host-support.v1.json']) {
   if (!files.includes(file)) files.push(file);
 }
 manifest.files = files;
@@ -26,5 +29,5 @@ fs.writeFileSync(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`);
 console.log(JSON.stringify({
   packaged: true,
   pkgDir,
-  files: ['node.mjs', 'host-support.v1.json'],
+  files: ['node.mjs', 'node.d.mts', 'host-support.v1.json'],
 }, null, 2));


### PR DESCRIPTION
Closes #77.

Adds Node as a verified host environment for the packaged Burn/WASM runtime without changing core runtime semantics.

Changes:
- packages `node.mjs` beside the generated wasm-bindgen web artifact
- Node adapter reads the sibling WASM file and calls `initSync`, avoiding unsupported default async `file://` fetch behavior
- packages `host-support.v1.json` as machine-readable host metadata
- patches generated `package.json` so the adapter and host metadata are retained in the artifact file set
- CI validates host-support JSON, packages the Node adapter, and runs a Node host smoke test against the built artifact
- smoke test verifies program capabilities, Program Bundle capabilities, and actual graph execution

Invariants preserved:
- no Burn execution change
- no program identity/binding change
- no Program Bundle schema change
- existing web-target files and APIs remain unchanged
- host support stays outside core proof/runtime semantics